### PR TITLE
Enable ORCID authority control

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -748,7 +748,7 @@ event.dispatcher.default.class = org.dspace.event.BasicDispatcher
 # Add doi here if you are using org.dspace.identifier.DOIIdentifierProvider to generate DOIs.
 # Adding doi here makes DSpace send metadata updates to your doi registration agency.
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
-event.dispatcher.default.consumers = versioning, discovery, eperson, harvester
+event.dispatcher.default.consumers = authority, versioning, discovery, eperson, harvester
 
 # The noindex dispatcher will not create search or browse indexes (useful for batch item imports)
 event.dispatcher.noindex.class = org.dspace.event.BasicDispatcher
@@ -1598,8 +1598,8 @@ sherpa.romeo.url = http://www.sherpa.ac.uk/romeo/api29.php
 #  org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority
 
 #Uncomment to enable ORCID authority control
-#plugin.named.org.dspace.content.authority.ChoiceAuthority = \
-#    org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority
+plugin.named.org.dspace.content.authority.ChoiceAuthority = \
+    org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority
 
 ## The DCInputAuthority plugin is automatically configured with every
 ## value-pairs element in input-forms.xml, namely:
@@ -1639,12 +1639,12 @@ sherpa.romeo.url = http://www.sherpa.ac.uk/romeo/api29.php
 authority.minconfidence = ambiguous
 
 # Configuration settings for ORCID based authority control, uncomment the lines below to enable configuration
-#solr.authority.server=${solr.server}/authority
-#choices.plugin.dc.contributor.author = SolrAuthorAuthority
-#choices.presentation.dc.contributor.author = authorLookup
-#authority.controlled.dc.contributor.author = true
+solr.authority.server=${solr.server}/authority
+choices.plugin.dc.contributor.author = SolrAuthorAuthority
+choices.presentation.dc.contributor.author = authorLookup
+authority.controlled.dc.contributor.author = true
 #
-#authority.author.indexer.field.1=dc.contributor.author
+authority.author.indexer.field.1=dc.contributor.author
 
 ## demo: use LC plugin for author
 #choices.plugin.dc.contributor.author =  LCNameAuthority


### PR DESCRIPTION
The configuration in this branch enables the ORCID authority control.

There is also an additional command to run to assign initial authority values to authors in our existing VTechWorks index:
```
/dspace/bin/dspace index-authority
```
and another command that should run occasionally to update authority metadata from the ORCID web service:
```
/bin/dspace dsrun org.dspace.authority.UpdateAuthorities
```

More information is in the [DSpace 5 ORCID Integration documentation](https://wiki.duraspace.org/display/DSDOC6x/ORCID+Integration)