### PR TITLE
Parameterize assetstore configuration

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -147,15 +147,15 @@ mail.allowed.referrers = ${dspace.hostname}
 ##### File Storage ######
 
 # Asset (bitstream) store number 0 (zero)
-assetstore.dir = ${dspace.dir}/assetstore
+assetstore.dir = ${storage.assetstore.dir}
 
 # Specify extra asset stores like this, counting from 1 upwards:
-# assetstore.dir.1 = /second/assetstore
+assetstore.dir.1 = ${storage.assetstore.dir.1} 
 # assetstore.dir.2 = /third/assetstore
 
 # Specify the number of the store to use for new bitstreams with this property
 # The default is 0 (zero) which corresponds to the 'assetstore.dir' above
-# assetstore.incoming = 1
+assetstore.incoming = ${storage.assetstore.incoming} 
 
 
 ##### SRB File Storage #####


### PR DESCRIPTION
This change is in support of read-only access to production
assets from the pre-prod system, while allowing uploads and
item submissions to a development read/write storage area.

After getting this version of the dspace.cfg file, people will
also need to update the dspacedevvm.local.vt.edu.properties
file from the parameterize_assetstore branch in the vtlibans_dspace project
and copy it to the dspace directory.

Note: read-only access to production assets also requires
significant systems work.