### PR TITLE
Enable display of thumbnails in item lists

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2023,7 +2023,7 @@ webui.suggest.enable = false
 # best way. If you have a lot of images and other files 'file'
 # will be the best starting point
 # (metdata is the default value if this option is not specified)
-#xmlui.theme.mirage.item-list.emphasis = file
+xmlui.theme.mirage.item-list.emphasis = file
 
 ### Settings for the Item page in Mirage2 theme ###
 # Whether the title or the label of a file should be used to display it on the item page


### PR DESCRIPTION
@alawvt @amandafrench @AmberPoo1 
This may be what you had in mind for the item on the testing spreadsheet that mentions missing thumbnails.

See the attached screenshot and imagine that the word "Thumbnail" is an actual thumbnail. (Our LDEs don't have many bitstreams, including thumbnails in them, due to space issues).

<img width="976" alt="screen shot 2015-08-18 at 6 16 30 pm" src="https://cloud.githubusercontent.com/assets/6785790/9344259/4b0cbbae-45d5-11e5-9ff2-b0a4f7029e60.png">
