### PR TITLE
Add statistics links to home page

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1738,7 +1738,7 @@ upload.max = 536870912
 # should the stats be publicly available?  should be set to false if you only
 # want administrators to access the stats, or you do not intend to generate
 # any
-report.public = false
+report.public = true
 
 # directory where live reports are stored
 report.dir = ${dspace.dir}/reports/

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -14,11 +14,11 @@ resolver.timeout = 200
 # If disabled, anyone with READ permissions on the DSpaceObject will be able
 # to view the statistics.
 #View/download statistics
-authorization.admin.usage=true
+authorization.admin.usage=false
 #Search/search result statistics
-authorization.admin.search=true
+authorization.admin.search=false
 #Workflow result statistics
-authorization.admin.workflow=true
+authorization.admin.workflow=false
 
 # Enable/disable logging of spiders in solr statistics.
 # If false, and IP matches an address in spiderips.urls, event is not logged.


### PR DESCRIPTION

This adds:
    - Usage Statistics
    - Search Statistics
    - Workflow Statistics
links on the home page, and makes them available to all users.

This fixes issue #32