### PR TITLE
Enable video playback on item pages

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2036,7 +2036,7 @@ mirage2.item-view.bitstream.href.label.2 = title
 # into an existing item through the administrative interface. If the user does not
 # have the appropriate privileges (add & write) on the bundle then that bundle will
 # not be shown to the user as an option.
-#xmlui.bundle.upload = ORIGINAL, METADATA, THUMBNAIL, LICENSE, CC-LICENSE
+xmlui.bundle.upload = ORIGINAL, METADATA, THUMBNAIL, MOVIEPOSTER, LICENSE, CC-LICENSE
 
 # On the community-list page should all the metadata about a community/collection
 # be available to the theme. This parameter defaults to true, but if you are

--- a/dspace/config/registries/bitstream-formats.xml
+++ b/dspace/config/registries/bitstream-formats.xml
@@ -733,5 +733,32 @@
       <extension>rdf</extension>
     </bitstream-type>
 
+    <bitstream-type>
+      <mimetype>video/mp4</mimetype>
+      <short_description>MP4 Container</short_description>
+      <description>MP4 Container format for video files</description>
+      <support_level>0</support_level>
+      <internal>false</internal>
+      <extension>m4v</extension>
+      <extension>mp4</extension>
+    </bitstream-type>
+
+    <bitstream-type>
+      <mimetype>video/webm</mimetype>
+      <short_description>webm video</short_description>
+      <description>The webm video container format</description>
+      <support_level>0</support_level>
+      <internal>false</internal>
+      <extension>webm</extension>
+    </bitstream-type>
+
+    <bitstream-type>
+      <mimetype>text/vtt</mimetype>
+      <short_description>WebVTT caption file</short_description>
+      <description>Closed caption or subtitle file for HTML5 video</description>
+      <support_level>1</support_level>
+      <internal>false</internal>
+      <extension>vtt</extension>
+    </bitstream-type>
 
 </dspace-bitstream-types>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -1,0 +1,789 @@
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+
+<!--
+    Rendering specific to the item display page.
+
+    Author: art.lowel at atmire.com
+    Author: lieven.droogmans at atmire.com
+    Author: ben at atmire.com
+    Author: Alexey Maslov
+
+-->
+
+<xsl:stylesheet
+    xmlns:i18n="http://apache.org/cocoon/i18n/2.1"
+    xmlns:dri="http://di.tamu.edu/DRI/1.0/"
+    xmlns:mets="http://www.loc.gov/METS/"
+    xmlns:dim="http://www.dspace.org/xmlns/dspace/dim"
+    xmlns:xlink="http://www.w3.org/TR/xlink/"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:atom="http://www.w3.org/2005/Atom"
+    xmlns:ore="http://www.openarchives.org/ore/terms/"
+    xmlns:oreatom="http://www.openarchives.org/ore/atom/"
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:xalan="http://xml.apache.org/xalan"
+    xmlns:encoder="xalan://java.net.URLEncoder"
+    xmlns:util="org.dspace.app.xmlui.utils.XSLUtils"
+    xmlns:jstring="java.lang.String"
+    xmlns:rights="http://cosimo.stanford.edu/sdr/metsrights/"
+    xmlns:confman="org.dspace.core.ConfigurationManager"
+    exclude-result-prefixes="xalan encoder i18n dri mets dim xlink xsl util jstring rights confman">
+
+    <xsl:output indent="yes"/>
+
+    <xsl:template name="itemSummaryView-DIM">
+
+        <!-- V.T. Add HTML for the video in a videojs frame -->
+ 
+        <xsl:if test="(./mets:fileSec/mets:fileGrp[@USE='CONTENT']/mets:file[@MIMETYPE='video/mp4']) and (./mets:fileSec/mets:fileGrp[@USE='CONTENT']/mets:file[@MIMETYPE='video/webm'])">
+
+             <!-- V.T. Best guess at aspect ratio of most of our videos -->
+             <video controls="controls" preload="none" width="853" height="480" class="video-js vjs-default-skin" data-setup="">
+
+                 <xsl:if test="./mets:fileSec/mets:fileGrp[@USE='MOVIEPOSTER']">
+                     <xsl:attribute name="poster">
+                         <xsl:value-of 
+                            select="./mets:fileSec/mets:fileGrp[@USE='MOVIEPOSTER']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href" />
+                     </xsl:attribute>
+                 </xsl:if>
+                 
+                 <source type="video/webm" >
+                 <xsl:attribute name="src">
+                     <xsl:value-of
+                        select="./mets:fileSec/mets:fileGrp[@USE='CONTENT']/mets:file[@MIMETYPE='video/webm']/mets:FLocat[@LOCTYPE='URL']/@xlink:href" />
+                 </xsl:attribute>
+                 </source>
+
+                <source type="video/mp4">
+                <xsl:attribute name="src">
+                    <xsl:value-of
+                      select="./mets:fileSec/mets:fileGrp[@USE='CONTENT']/mets:file[@MIMETYPE='video/mp4']/mets:FLocat[@LOCTYPE='URL']/@xlink:href" />
+                </xsl:attribute>
+                </source>
+                
+               <!-- V.T. display captions -->
+               <xsl:if test="./mets:fileSec/mets:fileGrp[@USE='CONTENT']/mets:file[@MIMETYPE='text/vtt']">
+
+               <track kind="captions" srclang="en" label="English" default="default">
+               <xsl:attribute name="src">
+               <xsl:value-of
+                 select="./mets:fileSec/mets:fileGrp[@USE='CONTENT']/mets:file[@MIMETYPE='text/vtt']/mets:FLocat[@LOCTYPE='URL']/@xlink:href" />
+               </xsl:attribute>
+               </track>
+               </xsl:if>
+
+              </video>
+           <hr />
+           </xsl:if>
+
+
+        <!-- Generate the info about the item from the metadata section -->
+        <xsl:apply-templates select="./mets:dmdSec/mets:mdWrap[@OTHERMDTYPE='DIM']/mets:xmlData/dim:dim"
+        mode="itemSummaryView-DIM"/>
+
+        <xsl:copy-of select="$SFXLink" />
+
+        <!-- Generate the Creative Commons license information from the file section (DSpace deposit license hidden by default)-->
+        <xsl:if test="./mets:fileSec/mets:fileGrp[@USE='CC-LICENSE' or @USE='LICENSE']">
+            <div class="license-info table">
+                <p>
+                    <i18n:text>xmlui.dri2xhtml.METS-1.0.license-text</i18n:text>
+                </p>
+                <ul class="list-unstyled">
+                    <xsl:apply-templates select="./mets:fileSec/mets:fileGrp[@USE='CC-LICENSE' or @USE='LICENSE']" mode="simple"/>
+                </ul>
+            </div>
+        </xsl:if>
+
+
+    </xsl:template>
+
+    <!-- An item rendered in the detailView pattern, the "full item record" view of a DSpace item in Manakin. -->
+    <xsl:template name="itemDetailView-DIM">
+        <!-- Output all of the metadata about the item from the metadata section -->
+        <xsl:apply-templates select="mets:dmdSec/mets:mdWrap[@OTHERMDTYPE='DIM']/mets:xmlData/dim:dim"
+                             mode="itemDetailView-DIM"/>
+
+        <!-- Generate the bitstream information from the file section -->
+        <xsl:choose>
+            <xsl:when test="./mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file">
+                <h3><i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-head</i18n:text></h3>
+                <div class="file-list">
+                    <xsl:apply-templates select="./mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE' or @USE='CC-LICENSE']">
+                        <xsl:with-param name="context" select="."/>
+                        <xsl:with-param name="primaryBitstream" select="./mets:structMap[@TYPE='LOGICAL']/mets:div[@TYPE='DSpace Item']/mets:fptr/@FILEID"/>
+                    </xsl:apply-templates>
+                </div>
+            </xsl:when>
+            <!-- Special case for handling ORE resource maps stored as DSpace bitstreams -->
+            <xsl:when test="./mets:fileSec/mets:fileGrp[@USE='ORE']">
+                <xsl:apply-templates select="./mets:fileSec/mets:fileGrp[@USE='ORE']" mode="itemDetailView-DIM" />
+            </xsl:when>
+            <xsl:otherwise>
+                <h2><i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-head</i18n:text></h2>
+                <table class="ds-table file-list">
+                    <tr class="ds-table-header-row">
+                        <th><i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-file</i18n:text></th>
+                        <th><i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-size</i18n:text></th>
+                        <th><i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-format</i18n:text></th>
+                        <th><i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-view</i18n:text></th>
+                    </tr>
+                    <tr>
+                        <td colspan="4">
+                            <p><i18n:text>xmlui.dri2xhtml.METS-1.0.item-no-files</i18n:text></p>
+                        </td>
+                    </tr>
+                </table>
+            </xsl:otherwise>
+        </xsl:choose>
+
+    </xsl:template>
+
+
+    <xsl:template match="dim:dim" mode="itemSummaryView-DIM">
+        <div class="item-summary-view-metadata">
+            <xsl:call-template name="itemSummaryView-DIM-title"/>
+            <div class="row">
+                <div class="col-sm-4">
+                    <div class="row">
+                        <div class="col-xs-6 col-sm-12">
+                            <xsl:call-template name="itemSummaryView-DIM-thumbnail"/>
+                        </div>
+                        <div class="col-xs-6 col-sm-12">
+                            <xsl:call-template name="itemSummaryView-DIM-file-section"/>
+                        </div>
+                    </div>
+                    <xsl:call-template name="itemSummaryView-DIM-date"/>
+                    <xsl:call-template name="itemSummaryView-DIM-authors"/>
+                    <xsl:if test="$ds_item_view_toggle_url != ''">
+                        <xsl:call-template name="itemSummaryView-show-full"/>
+                    </xsl:if>
+                </div>
+                <div class="col-sm-8">
+                    <xsl:call-template name="itemSummaryView-DIM-abstract"/>
+                    <xsl:call-template name="itemSummaryView-DIM-URI"/>
+                    <xsl:call-template name="itemSummaryView-collections"/>
+                </div>
+            </div>
+        </div>
+    </xsl:template>
+
+    <xsl:template name="itemSummaryView-DIM-title">
+        <xsl:choose>
+            <xsl:when test="count(dim:field[@element='title'][not(@qualifier)]) &gt; 1">
+                <h2 class="page-header first-page-header">
+                    <xsl:value-of select="dim:field[@element='title'][not(@qualifier)][1]/node()"/>
+                </h2>
+                <div class="simple-item-view-other">
+                    <p class="lead">
+                        <xsl:for-each select="dim:field[@element='title'][not(@qualifier)]">
+                            <xsl:if test="not(position() = 1)">
+                                <xsl:value-of select="./node()"/>
+                                <xsl:if test="count(following-sibling::dim:field[@element='title'][not(@qualifier)]) != 0">
+                                    <xsl:text>; </xsl:text>
+                                    <br/>
+                                </xsl:if>
+                            </xsl:if>
+
+                        </xsl:for-each>
+                    </p>
+                </div>
+            </xsl:when>
+            <xsl:when test="count(dim:field[@element='title'][not(@qualifier)]) = 1">
+                <h2 class="page-header first-page-header">
+                    <xsl:value-of select="dim:field[@element='title'][not(@qualifier)][1]/node()"/>
+                </h2>
+            </xsl:when>
+            <xsl:otherwise>
+                <h2 class="page-header first-page-header">
+                    <i18n:text>xmlui.dri2xhtml.METS-1.0.no-title</i18n:text>
+                </h2>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="itemSummaryView-DIM-thumbnail">
+        <div class="thumbnail">
+            <xsl:choose>
+                <xsl:when test="//mets:fileSec/mets:fileGrp[@USE='THUMBNAIL']">
+                    <xsl:variable name="src">
+                        <xsl:choose>
+                            <xsl:when test="/mets:METS/mets:fileSec/mets:fileGrp[@USE='THUMBNAIL']/mets:file[@GROUPID=../../mets:fileGrp[@USE='CONTENT']/mets:file[@GROUPID=../../mets:fileGrp[@USE='THUMBNAIL']/mets:file/@GROUPID][1]/@GROUPID]">
+                                <xsl:value-of
+                                        select="/mets:METS/mets:fileSec/mets:fileGrp[@USE='THUMBNAIL']/mets:file[@GROUPID=../../mets:fileGrp[@USE='CONTENT']/mets:file[@GROUPID=../../mets:fileGrp[@USE='THUMBNAIL']/mets:file/@GROUPID][1]/@GROUPID]/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of
+                                        select="//mets:fileSec/mets:fileGrp[@USE='THUMBNAIL']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:variable>
+                    <img alt="Thumbnail">
+                        <xsl:attribute name="src">
+                            <xsl:value-of select="$src"/>
+                        </xsl:attribute>
+                    </img>
+                </xsl:when>
+                <xsl:otherwise>
+                    <img alt="Thumbnail">
+                        <xsl:attribute name="data-src">
+                            <xsl:text>holder.js/100%x</xsl:text>
+                            <xsl:value-of select="$thumbnail.maxheight"/>
+                            <xsl:text>/text:No Thumbnail</xsl:text>
+                        </xsl:attribute>
+                    </img>
+                </xsl:otherwise>
+            </xsl:choose>
+        </div>
+    </xsl:template>
+
+    <xsl:template name="itemSummaryView-DIM-abstract">
+        <xsl:if test="dim:field[@element='description' and @qualifier='abstract']">
+            <div class="simple-item-view-description item-page-field-wrapper table">
+                <h5 class="visible-xs"><i18n:text>xmlui.dri2xhtml.METS-1.0.item-abstract</i18n:text></h5>
+                <div>
+                    <xsl:for-each select="dim:field[@element='description' and @qualifier='abstract']">
+                        <xsl:choose>
+                            <xsl:when test="node()">
+                                <xsl:copy-of select="node()"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:text>&#160;</xsl:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                        <xsl:if test="count(following-sibling::dim:field[@element='description' and @qualifier='abstract']) != 0">
+                            <div class="spacer">&#160;</div>
+                        </xsl:if>
+                    </xsl:for-each>
+                    <xsl:if test="count(dim:field[@element='description' and @qualifier='abstract']) &gt; 1">
+                        <div class="spacer">&#160;</div>
+                    </xsl:if>
+                </div>
+            </div>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="itemSummaryView-DIM-authors">
+        <xsl:if test="dim:field[@element='contributor'][@qualifier='author' and descendant::text()] or dim:field[@element='creator' and descendant::text()] or dim:field[@element='contributor' and descendant::text()]">
+            <div class="simple-item-view-authors item-page-field-wrapper table">
+                <h5><i18n:text>xmlui.dri2xhtml.METS-1.0.item-author</i18n:text></h5>
+                <xsl:choose>
+                    <xsl:when test="dim:field[@element='contributor'][@qualifier='author']">
+                        <xsl:for-each select="dim:field[@element='contributor'][@qualifier='author']">
+                            <xsl:call-template name="itemSummaryView-DIM-authors-entry" />
+                        </xsl:for-each>
+                    </xsl:when>
+                    <xsl:when test="dim:field[@element='creator']">
+                        <xsl:for-each select="dim:field[@element='creator']">
+                            <xsl:call-template name="itemSummaryView-DIM-authors-entry" />
+                        </xsl:for-each>
+                    </xsl:when>
+                    <xsl:when test="dim:field[@element='contributor']">
+                        <xsl:for-each select="dim:field[@element='contributor']">
+                            <xsl:call-template name="itemSummaryView-DIM-authors-entry" />
+                        </xsl:for-each>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <i18n:text>xmlui.dri2xhtml.METS-1.0.no-author</i18n:text>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </div>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="itemSummaryView-DIM-authors-entry">
+        <div>
+            <xsl:if test="@authority">
+                <xsl:attribute name="class"><xsl:text>ds-dc_contributor_author-authority</xsl:text></xsl:attribute>
+            </xsl:if>
+            <xsl:copy-of select="node()"/>
+        </div>
+    </xsl:template>
+
+    <xsl:template name="itemSummaryView-DIM-URI">
+        <xsl:if test="dim:field[@element='identifier' and @qualifier='uri' and descendant::text()]">
+            <div class="simple-item-view-uri item-page-field-wrapper table">
+                <h5><i18n:text>xmlui.dri2xhtml.METS-1.0.item-uri</i18n:text></h5>
+                <span>
+                    <xsl:for-each select="dim:field[@element='identifier' and @qualifier='uri']">
+                        <a>
+                            <xsl:attribute name="href">
+                                <xsl:copy-of select="./node()"/>
+                            </xsl:attribute>
+                            <xsl:copy-of select="./node()"/>
+                        </a>
+                        <xsl:if test="count(following-sibling::dim:field[@element='identifier' and @qualifier='uri']) != 0">
+                            <br/>
+                        </xsl:if>
+                    </xsl:for-each>
+                </span>
+            </div>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="itemSummaryView-DIM-date">
+        <xsl:if test="dim:field[@element='date' and @qualifier='issued' and descendant::text()]">
+            <div class="simple-item-view-date word-break item-page-field-wrapper table">
+                <h5>
+                    <i18n:text>xmlui.dri2xhtml.METS-1.0.item-date</i18n:text>
+                </h5>
+                <xsl:for-each select="dim:field[@element='date' and @qualifier='issued']">
+                    <xsl:copy-of select="substring(./node(),1,10)"/>
+                    <xsl:if test="count(following-sibling::dim:field[@element='date' and @qualifier='issued']) != 0">
+                        <br/>
+                    </xsl:if>
+                </xsl:for-each>
+            </div>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="itemSummaryView-show-full">
+        <div class="simple-item-view-show-full item-page-field-wrapper table">
+            <h5>
+                <i18n:text>xmlui.mirage2.itemSummaryView.MetaData</i18n:text>
+            </h5>
+            <a>
+                <xsl:attribute name="href"><xsl:value-of select="$ds_item_view_toggle_url"/></xsl:attribute>
+                <i18n:text>xmlui.ArtifactBrowser.ItemViewer.show_full</i18n:text>
+            </a>
+        </div>
+    </xsl:template>
+
+    <xsl:template name="itemSummaryView-collections">
+        <xsl:if test="$document//dri:referenceSet[@id='aspect.artifactbrowser.ItemViewer.referenceSet.collection-viewer']">
+            <div class="simple-item-view-collections item-page-field-wrapper table">
+                <h5>
+                    <i18n:text>xmlui.mirage2.itemSummaryView.Collections</i18n:text>
+                </h5>
+                <xsl:apply-templates select="$document//dri:referenceSet[@id='aspect.artifactbrowser.ItemViewer.referenceSet.collection-viewer']/dri:reference"/>
+            </div>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="itemSummaryView-DIM-file-section">
+        <xsl:choose>
+            <xsl:when test="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file">
+                <div class="item-page-field-wrapper table word-break">
+                    <h5>
+                        <i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-viewOpen</i18n:text>
+                    </h5>
+
+                    <xsl:variable name="label-1">
+                            <xsl:choose>
+                                <xsl:when test="confman:getProperty('mirage2.item-view.bitstream.href.label.1')">
+                                    <xsl:value-of select="confman:getProperty('mirage2.item-view.bitstream.href.label.1')"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:text>label</xsl:text>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                    </xsl:variable>
+
+                    <xsl:variable name="label-2">
+                            <xsl:choose>
+                                <xsl:when test="confman:getProperty('mirage2.item-view.bitstream.href.label.2')">
+                                    <xsl:value-of select="confman:getProperty('mirage2.item-view.bitstream.href.label.2')"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:text>title</xsl:text>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                    </xsl:variable>
+
+                    <xsl:for-each select="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file">
+                        <xsl:call-template name="itemSummaryView-DIM-file-section-entry">
+                            <xsl:with-param name="href" select="mets:FLocat[@LOCTYPE='URL']/@xlink:href" />
+                            <xsl:with-param name="mimetype" select="@MIMETYPE" />
+                            <xsl:with-param name="label-1" select="$label-1" />
+                            <xsl:with-param name="label-2" select="$label-2" />
+                            <xsl:with-param name="title" select="mets:FLocat[@LOCTYPE='URL']/@xlink:title" />
+                            <xsl:with-param name="label" select="mets:FLocat[@LOCTYPE='URL']/@xlink:label" />
+                            <xsl:with-param name="size" select="@SIZE" />
+                        </xsl:call-template>
+                    </xsl:for-each>
+                </div>
+            </xsl:when>
+            <!-- Special case for handling ORE resource maps stored as DSpace bitstreams -->
+            <xsl:when test="//mets:fileSec/mets:fileGrp[@USE='ORE']">
+                <xsl:apply-templates select="//mets:fileSec/mets:fileGrp[@USE='ORE']" mode="itemSummaryView-DIM" />
+            </xsl:when>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="itemSummaryView-DIM-file-section-entry">
+        <xsl:param name="href" />
+        <xsl:param name="mimetype" />
+        <xsl:param name="label-1" />
+        <xsl:param name="label-2" />
+        <xsl:param name="title" />
+        <xsl:param name="label" />
+        <xsl:param name="size" />
+        <div>
+            <a>
+                <xsl:attribute name="href">
+                    <xsl:value-of select="$href"/>
+                </xsl:attribute>
+                <xsl:call-template name="getFileIcon">
+                    <xsl:with-param name="mimetype">
+                        <xsl:value-of select="substring-before($mimetype,'/')"/>
+                        <xsl:text>/</xsl:text>
+                        <xsl:value-of select="substring-after($mimetype,'/')"/>
+                    </xsl:with-param>
+                </xsl:call-template>
+                <xsl:choose>
+                    <xsl:when test="contains($label-1, 'label') and string-length($label)!=0">
+                        <xsl:value-of select="$label"/>
+                    </xsl:when>
+                    <xsl:when test="contains($label-1, 'title') and string-length($title)!=0">
+                        <xsl:value-of select="$title"/>
+                    </xsl:when>
+                    <xsl:when test="contains($label-2, 'label') and string-length($label)!=0">
+                        <xsl:value-of select="$label"/>
+                    </xsl:when>
+                    <xsl:when test="contains($label-2, 'title') and string-length($title)!=0">
+                        <xsl:value-of select="$title"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:call-template name="getFileTypeDesc">
+                            <xsl:with-param name="mimetype">
+                                <xsl:value-of select="substring-before($mimetype,'/')"/>
+                                <xsl:text>/</xsl:text>
+                                <xsl:choose>
+                                    <xsl:when test="contains($mimetype,';')">
+                                        <xsl:value-of select="substring-before(substring-after($mimetype,'/'),';')"/>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:value-of select="substring-after($mimetype,'/')"/>
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                            </xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:otherwise>
+                </xsl:choose>
+                <xsl:text> (</xsl:text>
+                <xsl:choose>
+                    <xsl:when test="$size &lt; 1024">
+                        <xsl:value-of select="$size"/>
+                        <i18n:text>xmlui.dri2xhtml.METS-1.0.size-bytes</i18n:text>
+                    </xsl:when>
+                    <xsl:when test="$size &lt; 1024 * 1024">
+                        <xsl:value-of select="substring(string($size div 1024),1,5)"/>
+                        <i18n:text>xmlui.dri2xhtml.METS-1.0.size-kilobytes</i18n:text>
+                    </xsl:when>
+                    <xsl:when test="$size &lt; 1024 * 1024 * 1024">
+                        <xsl:value-of select="substring(string($size div (1024 * 1024)),1,5)"/>
+                        <i18n:text>xmlui.dri2xhtml.METS-1.0.size-megabytes</i18n:text>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="substring(string($size div (1024 * 1024 * 1024)),1,5)"/>
+                        <i18n:text>xmlui.dri2xhtml.METS-1.0.size-gigabytes</i18n:text>
+                    </xsl:otherwise>
+                </xsl:choose>
+                <xsl:text>)</xsl:text>
+            </a>
+        </div>
+    </xsl:template>
+
+    <xsl:template match="dim:dim" mode="itemDetailView-DIM">
+        <xsl:call-template name="itemSummaryView-DIM-title"/>
+        <div class="ds-table-responsive">
+            <table class="ds-includeSet-table detailtable table table-striped table-hover">
+                <xsl:apply-templates mode="itemDetailView-DIM"/>
+            </table>
+        </div>
+
+        <span class="Z3988">
+            <xsl:attribute name="title">
+                 <xsl:call-template name="renderCOinS"/>
+            </xsl:attribute>
+            &#xFEFF; <!-- non-breaking space to force separating the end tag -->
+        </span>
+        <xsl:copy-of select="$SFXLink" />
+    </xsl:template>
+
+    <xsl:template match="dim:field" mode="itemDetailView-DIM">
+            <tr>
+                <xsl:attribute name="class">
+                    <xsl:text>ds-table-row </xsl:text>
+                    <xsl:if test="(position() div 2 mod 2 = 0)">even </xsl:if>
+                    <xsl:if test="(position() div 2 mod 2 = 1)">odd </xsl:if>
+                </xsl:attribute>
+                <td class="label-cell">
+                    <xsl:value-of select="./@mdschema"/>
+                    <xsl:text>.</xsl:text>
+                    <xsl:value-of select="./@element"/>
+                    <xsl:if test="./@qualifier">
+                        <xsl:text>.</xsl:text>
+                        <xsl:value-of select="./@qualifier"/>
+                    </xsl:if>
+                </td>
+            <td class="word-break">
+              <xsl:copy-of select="./node()"/>
+            </td>
+                <td><xsl:value-of select="./@language"/></td>
+            </tr>
+    </xsl:template>
+
+    <!-- don't render the item-view-toggle automatically in the summary view, only when it gets called -->
+    <xsl:template match="dri:p[contains(@rend , 'item-view-toggle') and
+        (preceding-sibling::dri:referenceSet[@type = 'summaryView'] or following-sibling::dri:referenceSet[@type = 'summaryView'])]">
+    </xsl:template>
+
+    <!-- don't render the head on the item view page -->
+    <xsl:template match="dri:div[@n='item-view']/dri:head" priority="5">
+    </xsl:template>
+
+   <xsl:template match="mets:fileGrp[@USE='CONTENT']">
+        <xsl:param name="context"/>
+        <xsl:param name="primaryBitstream" select="-1"/>
+            <xsl:choose>
+                <!-- If one exists and it's of text/html MIME type, only display the primary bitstream -->
+                <xsl:when test="mets:file[@ID=$primaryBitstream]/@MIMETYPE='text/html'">
+                    <xsl:apply-templates select="mets:file[@ID=$primaryBitstream]">
+                        <xsl:with-param name="context" select="$context"/>
+                    </xsl:apply-templates>
+                </xsl:when>
+                <!-- Otherwise, iterate over and display all of them -->
+                <xsl:otherwise>
+                    <xsl:apply-templates select="mets:file">
+                     	<!--Do not sort any more bitstream order can be changed-->
+                        <xsl:with-param name="context" select="$context"/>
+                    </xsl:apply-templates>
+                </xsl:otherwise>
+            </xsl:choose>
+    </xsl:template>
+
+   <xsl:template match="mets:fileGrp[@USE='LICENSE']">
+        <xsl:param name="context"/>
+        <xsl:param name="primaryBitstream" select="-1"/>
+            <xsl:apply-templates select="mets:file">
+                        <xsl:with-param name="context" select="$context"/>
+            </xsl:apply-templates>
+    </xsl:template>
+
+    <xsl:template match="mets:file">
+        <xsl:param name="context" select="."/>
+        <div class="file-wrapper row">
+            <div class="col-xs-6 col-sm-3">
+                <div class="thumbnail">
+                    <a class="image-link">
+                        <xsl:attribute name="href">
+                            <xsl:value-of select="mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                        </xsl:attribute>
+                        <xsl:choose>
+                            <xsl:when test="$context/mets:fileSec/mets:fileGrp[@USE='THUMBNAIL']/
+                        mets:file[@GROUPID=current()/@GROUPID]">
+                                <img alt="Thumbnail">
+                                    <xsl:attribute name="src">
+                                        <xsl:value-of select="$context/mets:fileSec/mets:fileGrp[@USE='THUMBNAIL']/
+                                    mets:file[@GROUPID=current()/@GROUPID]/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                                    </xsl:attribute>
+                                </img>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <img alt="Thumbnail">
+                                    <xsl:attribute name="data-src">
+                                        <xsl:text>holder.js/100%x</xsl:text>
+                                        <xsl:value-of select="$thumbnail.maxheight"/>
+                                        <xsl:text>/text:No Thumbnail</xsl:text>
+                                    </xsl:attribute>
+                                </img>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </a>
+                </div>
+            </div>
+
+            <div class="col-xs-6 col-sm-7">
+                <dl class="file-metadata dl-horizontal">
+                    <dt>
+                        <i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-name</i18n:text>
+                        <xsl:text>:</xsl:text>
+                    </dt>
+                    <dd class="word-break">
+                        <xsl:attribute name="title">
+                            <xsl:value-of select="mets:FLocat[@LOCTYPE='URL']/@xlink:title"/>
+                        </xsl:attribute>
+                        <xsl:value-of select="util:shortenString(mets:FLocat[@LOCTYPE='URL']/@xlink:title, 30, 5)"/>
+                    </dd>
+                <!-- File size always comes in bytes and thus needs conversion -->
+                    <dt>
+                        <i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-size</i18n:text>
+                        <xsl:text>:</xsl:text>
+                    </dt>
+                    <dd class="word-break">
+                        <xsl:choose>
+                            <xsl:when test="@SIZE &lt; 1024">
+                                <xsl:value-of select="@SIZE"/>
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.size-bytes</i18n:text>
+                            </xsl:when>
+                            <xsl:when test="@SIZE &lt; 1024 * 1024">
+                                <xsl:value-of select="substring(string(@SIZE div 1024),1,5)"/>
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.size-kilobytes</i18n:text>
+                            </xsl:when>
+                            <xsl:when test="@SIZE &lt; 1024 * 1024 * 1024">
+                                <xsl:value-of select="substring(string(@SIZE div (1024 * 1024)),1,5)"/>
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.size-megabytes</i18n:text>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="substring(string(@SIZE div (1024 * 1024 * 1024)),1,5)"/>
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.size-gigabytes</i18n:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </dd>
+                <!-- Lookup File Type description in local messages.xml based on MIME Type.
+         In the original DSpace, this would get resolved to an application via
+         the Bitstream Registry, but we are constrained by the capabilities of METS
+         and can't really pass that info through. -->
+                    <dt>
+                        <i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-format</i18n:text>
+                        <xsl:text>:</xsl:text>
+                    </dt>
+                    <dd class="word-break">
+                        <xsl:call-template name="getFileTypeDesc">
+                            <xsl:with-param name="mimetype">
+                                <xsl:value-of select="substring-before(@MIMETYPE,'/')"/>
+                                <xsl:text>/</xsl:text>
+                                <xsl:choose>
+                                    <xsl:when test="contains(@MIMETYPE,';')">
+                                <xsl:value-of select="substring-before(substring-after(@MIMETYPE,'/'),';')"/>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:value-of select="substring-after(@MIMETYPE,'/')"/>
+                                    </xsl:otherwise>
+                                </xsl:choose>
+
+                            </xsl:with-param>
+                        </xsl:call-template>
+                    </dd>
+                <!-- Display the contents of 'Description' only if bitstream contains a description -->
+                <xsl:if test="mets:FLocat[@LOCTYPE='URL']/@xlink:label != ''">
+                        <dt>
+                            <i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-description</i18n:text>
+                            <xsl:text>:</xsl:text>
+                        </dt>
+                        <dd class="word-break">
+                            <xsl:attribute name="title">
+                                <xsl:value-of select="mets:FLocat[@LOCTYPE='URL']/@xlink:label"/>
+                            </xsl:attribute>
+                            <xsl:value-of select="util:shortenString(mets:FLocat[@LOCTYPE='URL']/@xlink:label, 30, 5)"/>
+                        </dd>
+                </xsl:if>
+                </dl>
+            </div>
+
+            <div class="file-link col-xs-6 col-xs-offset-6 col-sm-2 col-sm-offset-0">
+                <xsl:choose>
+                    <xsl:when test="@ADMID">
+                        <xsl:call-template name="display-rights"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:call-template name="view-open"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </div>
+        </div>
+
+</xsl:template>
+
+    <xsl:template name="view-open">
+        <a>
+            <xsl:attribute name="href">
+                <xsl:value-of select="mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+            </xsl:attribute>
+            <i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-viewOpen</i18n:text>
+        </a>
+    </xsl:template>
+
+    <xsl:template name="display-rights">
+        <xsl:variable name="file_id" select="jstring:replaceAll(jstring:replaceAll(string(@ADMID), '_METSRIGHTS', ''), 'rightsMD_', '')"/>
+        <xsl:variable name="rights_declaration" select="../../../mets:amdSec/mets:rightsMD[@ID = concat('rightsMD_', $file_id, '_METSRIGHTS')]/mets:mdWrap/mets:xmlData/rights:RightsDeclarationMD"/>
+        <xsl:variable name="rights_context" select="$rights_declaration/rights:Context"/>
+        <xsl:variable name="users">
+            <xsl:for-each select="$rights_declaration/*">
+                <xsl:value-of select="rights:UserName"/>
+                <xsl:choose>
+                    <xsl:when test="rights:UserName/@USERTYPE = 'GROUP'">
+                       <xsl:text> (group)</xsl:text>
+                    </xsl:when>
+                    <xsl:when test="rights:UserName/@USERTYPE = 'INDIVIDUAL'">
+                       <xsl:text> (individual)</xsl:text>
+                    </xsl:when>
+                </xsl:choose>
+                <xsl:if test="position() != last()">, </xsl:if>
+            </xsl:for-each>
+        </xsl:variable>
+
+        <xsl:choose>
+            <xsl:when test="not ($rights_context/@CONTEXTCLASS = 'GENERAL PUBLIC') and ($rights_context/rights:Permissions/@DISPLAY = 'true')">
+                <a href="{mets:FLocat[@LOCTYPE='URL']/@xlink:href}">
+                    <img width="64" height="64" src="{concat($theme-path,'/images/Crystal_Clear_action_lock3_64px.png')}" title="Read access available for {$users}"/>
+                    <!-- icon source: http://commons.wikimedia.org/wiki/File:Crystal_Clear_action_lock3.png -->
+                </a>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="view-open"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="getFileIcon">
+        <xsl:param name="mimetype"/>
+            <i aria-hidden="true">
+                <xsl:attribute name="class">
+                <xsl:text>glyphicon </xsl:text>
+                <xsl:choose>
+                    <xsl:when test="contains(mets:FLocat[@LOCTYPE='URL']/@xlink:href,'isAllowed=n')">
+                        <xsl:text> glyphicon-lock</xsl:text>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:text> glyphicon-file</xsl:text>
+                    </xsl:otherwise>
+                </xsl:choose>
+                </xsl:attribute>
+            </i>
+        <xsl:text> </xsl:text>
+    </xsl:template>
+
+    <!-- Generate the license information from the file section -->
+    <xsl:template match="mets:fileGrp[@USE='CC-LICENSE']" mode="simple">
+        <li><a href="{mets:file/mets:FLocat[@xlink:title='license_text']/@xlink:href}"><i18n:text>xmlui.dri2xhtml.structural.link_cc</i18n:text></a></li>
+    </xsl:template>
+
+    <!-- Generate the license information from the file section -->
+    <xsl:template match="mets:fileGrp[@USE='LICENSE']" mode="simple">
+        <li><a href="{mets:file/mets:FLocat[@xlink:title='license.txt']/@xlink:href}"><i18n:text>xmlui.dri2xhtml.structural.link_original_license</i18n:text></a></li>
+    </xsl:template>
+
+    <!--
+    File Type Mapping template
+
+    This maps format MIME Types to human friendly File Type descriptions.
+    Essentially, it looks for a corresponding 'key' in your messages.xml of this
+    format: xmlui.dri2xhtml.mimetype.{MIME Type}
+
+    (e.g.) <message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
+
+    If a key is found, the translated value is displayed as the File Type (e.g. PDF)
+    If a key is NOT found, the MIME Type is displayed by default (e.g. application/pdf)
+    -->
+    <xsl:template name="getFileTypeDesc">
+        <xsl:param name="mimetype"/>
+
+        <!--Build full key name for MIME type (format: xmlui.dri2xhtml.mimetype.{MIME type})-->
+        <xsl:variable name="mimetype-key">xmlui.dri2xhtml.mimetype.<xsl:value-of select='$mimetype'/></xsl:variable>
+
+        <!--Lookup the MIME Type's key in messages.xml language file.  If not found, just display MIME Type-->
+        <i18n:text i18n:key="{$mimetype-key}"><xsl:value-of select="$mimetype"/></i18n:text>
+    </xsl:template>
+
+
+</xsl:stylesheet>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/core/page-structure.xsl
@@ -268,6 +268,14 @@
             <!-- Modernizr enables HTML5 elements & feature detects -->
             <script src="{concat($theme-path, 'vendor/modernizr/modernizr.js')}">&#160;</script>
 
+            <!-- include css and javascript for video playback -->
+
+            <link type="text/css" rel="stylesheet">
+            <xsl:attribute name="href">http://vjs.zencdn.net/c/video-js.css</xsl:attribute>
+            </link>
+
+            <script src="http://vjs.zencdn.net/c/video.js">&#160;</script>
+
             <!-- Add the title in -->
             <xsl:variable name="page_title" select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='title'][last()]" />
             <title>

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/cocoon/BitstreamReader.java
@@ -1,0 +1,782 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+// This file has been modfied to support video
+// playback in the VTechWorks repository.
+//
+//  - Byte range logic uncommented
+//  - off by one error in byte range logic fixed
+//  - byte range headers fixed
+//
+//  Theme support and mime type registry adjustment is also required
+
+package org.dspace.app.xmlui.cocoon;
+
+import java.io.*;
+import java.net.URLEncoder;
+import java.sql.SQLException;
+import java.util.Map;
+
+import javax.mail.internet.MimeUtility;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.avalon.excalibur.pool.Recyclable;
+import org.apache.avalon.framework.parameters.Parameters;
+import org.apache.cocoon.ProcessingException;
+import org.apache.cocoon.ResourceNotFoundException;
+import org.apache.cocoon.environment.ObjectModelHelper;
+import org.apache.cocoon.environment.Request;
+import org.apache.cocoon.environment.Response;
+import org.apache.cocoon.environment.SourceResolver;
+import org.apache.cocoon.environment.http.HttpEnvironment;
+import org.apache.cocoon.environment.http.HttpResponse;
+import org.apache.cocoon.reading.AbstractReader;
+import org.apache.cocoon.util.ByteRange;
+import org.apache.commons.lang.StringUtils;
+import org.dspace.app.xmlui.utils.AuthenticationUtil;
+import org.dspace.app.xmlui.utils.ContextUtil;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.disseminate.CitationDocument;
+import org.dspace.handle.HandleManager;
+import org.dspace.usage.UsageEvent;
+import org.dspace.utils.DSpace;
+import org.xml.sax.SAXException;
+
+import org.apache.log4j.Logger;
+import org.dspace.core.LogManager;
+
+/**
+ * The BitstreamReader will query DSpace for a particular bitstream and transmit
+ * it to the user. There are several methods of specifing the bitstream to be
+ * delivered. You may reference a bitstream by either it's id or attempt to
+ * resolve the bitstream's name.
+ *
+ *  /bitstream/{handle}/{sequence}/{name}
+ *
+ *  &lt;map:read type="BitstreamReader">
+ *    &lt;map:parameter name="handle" value="{1}/{2}"/&gt;
+ *    &lt;map:parameter name="sequence" value="{3}"/&gt;
+ *    &lt;map:parameter name="name" value="{4}"/&gt;
+ *  &lt;/map:read&gt;
+ *
+ *  When no handle is assigned yet you can access a bitstream
+ *  using it's internal ID.
+ *
+ *  /bitstream/id/{bitstreamID}/{sequence}/{name}
+ *
+ *  &lt;map:read type="BitstreamReader">
+ *    &lt;map:parameter name="bitstreamID" value="{1}"/&gt;
+ *    &lt;map:parameter name="sequence" value="{2}"/&gt;
+ *  &lt;/map:read&gt;
+ *
+ *  Alternatively, you can access the bitstream via a name instead
+ *  of directly through it's sequence.
+ *
+ *  /html/{handle}/{name}
+ *
+ *  &lt;map:read type="BitstreamReader"&gt;
+ *    &lt;map:parameter name="handle" value="{1}/{2}"/&gt;
+ *    &lt;map:parameter name="name" value="{3}"/&gt;
+ *  &lt;/map:read&gt;
+ *
+ *  Again when no handle is available you can also access it
+ *  via an internal itemID & name.
+ *
+ *  /html/id/{itemID}/{name}
+ *
+ *  &lt;map:read type="BitstreamReader"&gt;
+ *    &lt;map:parameter name="itemID" value="{1}"/&gt;
+ *    &lt;map:parameter name="name" value="{2}"/&gt;
+ *  &lt;/map:read&gt;
+ *
+ * Added request-item support. 
+ * Original Concept, JSPUI version:    Universidade do Minho   at www.uminho.pt
+ * Sponsorship of XMLUI version:    Instituto Oceanográfico de España at www.ieo.es
+ * 
+ * @author Scott Phillips
+ * @author Adán Román Ruiz at arvo.es (added request item support)
+ */
+
+public class BitstreamReader extends AbstractReader implements Recyclable
+{
+    private static Logger log = Logger.getLogger(BitstreamReader.class);
+        
+    /**
+     * Messages to be sent when the user is not authorized to view
+     * a particular bitstream. They will be redirected to the login
+     * where this message will be displayed.
+     */
+    private static final String AUTH_REQUIRED_HEADER = "xmlui.BitstreamReader.auth_header";
+    private static final String AUTH_REQUIRED_MESSAGE = "xmlui.BitstreamReader.auth_message";
+        
+    /**
+     * How big a buffer should we use when reading from the bitstream before
+     * writing to the HTTP response?
+     */
+    protected static final int BUFFER_SIZE = 8192;
+
+    /**
+     * When should a bitstream expire in milliseconds. This should be set to
+     * some low value just to prevent someone hiting DSpace repeatedy from
+     * killing the server. Note: there are 1000 milliseconds in a second.
+     *
+     * Format: minutes * seconds * milliseconds
+     *  60 * 60 * 1000 == 1 hour
+     */
+    protected static final int expires = 60 * 60 * 1000;
+
+    /** The Cocoon response */
+    protected Response response;
+
+    /** The Cocoon request */
+    protected Request request;
+
+    /** The bitstream file */
+    protected InputStream bitstreamInputStream;
+    
+    /** The bitstream's reported size */
+    protected long bitstreamSize;
+    
+    /** The bitstream's mime-type */
+    protected String bitstreamMimeType;
+    
+    /** The bitstream's name */
+    protected String bitstreamName;
+    
+    /** True if bitstream is readable by anonymous users */
+    protected boolean isAnonymouslyReadable;
+
+    /** Item containing the Bitstream */
+    private Item item = null;
+
+    /** True if user agent making this request was identified as spider. */
+    private boolean isSpider = false;
+
+    /** TEMP file for citation PDF. We will save here, so we can delete the temp file when done.  */
+    private File tempFile;
+
+    /**
+     * Set up the bitstream reader.
+     *
+     * See the class description for information on configuration options.
+     */
+    public void setup(SourceResolver resolver, Map objectModel, String src,
+            Parameters par) throws ProcessingException, SAXException,
+            IOException
+    {
+        super.setup(resolver, objectModel, src, par);
+
+        try
+        {
+            this.request = ObjectModelHelper.getRequest(objectModel);
+            this.response = ObjectModelHelper.getResponse(objectModel);
+            
+            // Check to see if a context already exists or not. We may
+            // have been aggregated into an http request by the XSL document
+            // pulling in an XML-based bitstream. In this case the context has
+            // already been created and we should leave it open because the
+            // normal processes will close it.
+            boolean BitstreamReaderOpenedContext = !ContextUtil.isContextAvailable(objectModel);
+            Context context = ContextUtil.obtainContext(objectModel);
+            
+            // Get our parameters that identify the bitstream
+            int itemID = par.getParameterAsInteger("itemID", -1);
+            int bitstreamID = par.getParameterAsInteger("bitstreamID", -1);
+            String handle = par.getParameter("handle", null);
+            
+            int sequence = par.getParameterAsInteger("sequence", -1);
+            String name = par.getParameter("name", null);
+        
+            this.isSpider = par.getParameter("userAgent", "").equals("spider");
+
+            // Resolve the bitstream
+            Bitstream bitstream = null;
+            DSpaceObject dso = null;
+            
+            if (bitstreamID > -1)
+            {
+                // Direct reference to the individual bitstream ID.
+                bitstream = Bitstream.find(context, bitstreamID);
+            }
+            else if (itemID > -1)
+            {
+                // Referenced by internal itemID
+                item = Item.find(context, itemID);
+                
+                if (sequence > -1)
+                {
+                        bitstream = findBitstreamBySequence(item, sequence);
+                }
+                else if (name != null)
+                {
+                        bitstream = findBitstreamByName(item, name);
+                }
+            }
+            else if (handle != null)
+            {
+                // Reference by an item's handle.
+                dso = HandleManager.resolveToObject(context,handle);
+
+                if (dso instanceof Item)
+                {
+                    item = (Item)dso;
+
+                    if (sequence > -1)
+                    {
+                        bitstream = findBitstreamBySequence(item,sequence);
+                    }
+                    else if (name != null)
+                    {
+                        bitstream = findBitstreamByName(item,name);
+                    }
+                }
+            }
+
+            // if initial search was by sequence number and found nothing,
+            // then try to find bitstream by name (assuming we have a file name)
+            if((sequence > -1 && bitstream==null) && name!=null)
+            {
+                bitstream = findBitstreamByName(item,name);
+
+                // if we found bitstream by name, send a redirect to its new sequence number location
+                if(bitstream!=null)
+                {
+                    String redirectURL = "";
+
+                    // build redirect URL based on whether item has a handle assigned yet
+                    if(item.getHandle()!=null && item.getHandle().length()>0)
+                    {
+                        redirectURL = request.getContextPath() + "/bitstream/handle/" + item.getHandle();
+                    }
+                    else
+                    {
+                        redirectURL = request.getContextPath() + "/bitstream/item/" + item.getID();
+                    }
+
+                        redirectURL += "/" + name + "?sequence=" + bitstream.getSequenceID();
+
+                        HttpServletResponse httpResponse = (HttpServletResponse)
+                        objectModel.get(HttpEnvironment.HTTP_RESPONSE_OBJECT);
+                        httpResponse.sendRedirect(redirectURL);
+                        return;
+                }
+            }
+
+            // Was a bitstream found?
+            if (bitstream == null)
+            {
+                throw new ResourceNotFoundException("Unable to locate bitstream");
+            }
+
+            // Is there a User logged in and does the user have access to read it?
+            boolean isAuthorized = AuthorizeManager.authorizeActionBoolean(context, bitstream, Constants.READ);
+            if (item != null && item.isWithdrawn() && !AuthorizeManager.isAdmin(context))
+            {
+                isAuthorized = false;
+                log.info(LogManager.getHeader(context, "view_bitstream", "handle=" + item.getHandle() + ",withdrawn=true"));
+            }
+            // It item-request is enabled to all request we redirect to restricted-resource immediately without login request  
+            String requestItemType = ConfigurationManager.getProperty("request.item.type");
+            if (!isAuthorized)
+            {
+                if(context.getCurrentUser() != null || StringUtils.equalsIgnoreCase("all", requestItemType)){
+                        // A user is logged in, but they are not authorized to read this bitstream,
+                        // instead of asking them to login again we'll point them to a friendly error
+                        // message that tells them the bitstream is restricted.
+                        String redictURL = request.getContextPath() + "/handle/";
+                        if (item!=null){
+                                redictURL += item.getHandle();
+                        }
+                        else if(dso!=null){
+                                redictURL += dso.getHandle();
+                        }
+                        redictURL += "/restricted-resource?bitstreamId=" + bitstream.getID();
+
+                        HttpServletResponse httpResponse = (HttpServletResponse)
+                        objectModel.get(HttpEnvironment.HTTP_RESPONSE_OBJECT);
+                        httpResponse.sendRedirect(redictURL);
+                        return;
+                }
+                else{
+                	if(ConfigurationManager.getProperty("request.item.type")==null||
+                			                			ConfigurationManager.getProperty("request.item.type").equalsIgnoreCase("logged")){
+                        // The user does not have read access to this bitstream. Interrupt this current request
+                        // and then forward them to the login page so that they can be authenticated. Once that is
+                        // successful, their request will be resumed.
+                        AuthenticationUtil.interruptRequest(objectModel, AUTH_REQUIRED_HEADER, AUTH_REQUIRED_MESSAGE, null);
+
+                        // Redirect
+                        String redictURL = request.getContextPath() + "/login";
+
+                        HttpServletResponse httpResponse = (HttpServletResponse)
+                        objectModel.get(HttpEnvironment.HTTP_RESPONSE_OBJECT);
+                        httpResponse.sendRedirect(redictURL);
+                        return;
+                	}
+                }
+            }
+
+            // Success, bitstream found and the user has access to read it.
+            // Store these for later retrieval:
+
+            // Intercepting views to the original bitstream to instead show a citation altered version of the object
+            // We need to check if this resource falls under the "show watermarked alternative" umbrella.
+            // At which time we will not return the "bitstream", but will instead on-the-fly generate the citation rendition.
+
+            // What will trigger a redirect/intercept?
+            // 1) Intercepting Enabled
+            // 2) This User is not an admin
+            // 3) This object is citation-able
+            if (CitationDocument.isCitationEnabledForBitstream(bitstream, context)) {
+                // on-the-fly citation generator
+                log.info(item.getHandle() + " - " + bitstream.getName() + " is citable.");
+
+                FileInputStream fileInputStream = null;
+                CitationDocument citationDocument = new CitationDocument();
+
+                try {
+                    //Create the cited document
+                    tempFile = citationDocument.makeCitedDocument(bitstream);
+                    if(tempFile == null) {
+                        log.error("CitedDocument was null");
+                    } else {
+                        log.info("CitedDocument was ok," + tempFile.getAbsolutePath());
+                    }
+
+
+                    fileInputStream = new FileInputStream(tempFile);
+                    if(fileInputStream == null) {
+                        log.error("Error opening fileInputStream: ");
+                    }
+
+                    this.bitstreamInputStream = fileInputStream;
+                    this.bitstreamSize = tempFile.length();
+
+                } catch (Exception e) {
+                    log.error("Caught an error with intercepting the citation document:" + e.getMessage());
+                }
+
+                //End of CitationDocument
+            } else {
+                this.bitstreamInputStream = bitstream.retrieve();
+                this.bitstreamSize = bitstream.getSize();
+            }
+
+            this.bitstreamMimeType = bitstream.getFormat().getMIMEType();
+            this.bitstreamName = bitstream.getName();
+            if (context.getCurrentUser() == null)
+            {
+                this.isAnonymouslyReadable = true;
+            }
+            else
+            {
+                this.isAnonymouslyReadable = false;
+                for (ResourcePolicy rp : AuthorizeManager.getPoliciesActionFilter(context, bitstream, Constants.READ))
+                {
+                    if (rp.getGroupID() == 0)
+                    {
+                        this.isAnonymouslyReadable = true;
+                    }
+                }
+            }
+
+            // Trim any path information from the bitstream
+            if (bitstreamName != null && bitstreamName.length() >0 )
+            {
+                        int finalSlashIndex = bitstreamName.lastIndexOf('/');
+                        if (finalSlashIndex > 0)
+                        {
+                                bitstreamName = bitstreamName.substring(finalSlashIndex+1);
+                        }
+            }
+            else
+            {
+                // In-case there is no bitstream name...
+                if(name != null && name.length() > 0) {
+                    bitstreamName = name;
+                    if(name.endsWith(".jpg")) {
+                        bitstreamMimeType = "image/jpeg";
+                    } else if(name.endsWith(".png")) {
+                        bitstreamMimeType = "image/png";
+                    }
+                } else {
+                    bitstreamName = "bitstream";
+                }
+            }
+            
+            // Log that the bitstream has been viewed, this is non-cached and the complexity
+            // of adding it to the sitemap for every possible bitstream uri is not very tractable
+            new DSpace().getEventService().fireEvent(
+                                new UsageEvent(
+                                                UsageEvent.Action.VIEW,
+                                                ObjectModelHelper.getRequest(objectModel),
+                                                ContextUtil.obtainContext(ObjectModelHelper.getRequest(objectModel)),
+                                                bitstream));
+            
+            // If we created the database connection close it, otherwise leave it open.
+            if (BitstreamReaderOpenedContext)
+            	context.complete();
+        }
+        catch (SQLException sqle)
+        {
+            throw new ProcessingException("Unable to read bitstream.",sqle);
+        }
+        catch (AuthorizeException ae)
+        {
+            throw new ProcessingException("Unable to read bitstream.",ae);
+        }
+    }
+
+    
+    
+    
+    
+    /**
+     * Find the bitstream identified by a sequence number on this item.
+     *
+     * @param item A DSpace item
+     * @param sequence The sequence of the bitstream
+     * @return The bitstream or null if none found.
+     */
+    private Bitstream findBitstreamBySequence(Item item, int sequence) throws SQLException
+    {
+        if (item == null)
+        {
+            return null;
+        }
+        
+        Bundle[] bundles = item.getBundles();
+        for (Bundle bundle : bundles)
+        {
+            Bitstream[] bitstreams = bundle.getBitstreams();
+
+            for (Bitstream bitstream : bitstreams)
+            {
+                if (bitstream.getSequenceID() == sequence)
+                {
+                        return bitstream;
+                }
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * Return the bitstream from the given item that is identified by the
+     * given name. If the name has prepended directories they will be removed
+     * one at a time until a bitstream is found. Note that if two bitstreams
+     * have the same name then the first bitstream will be returned.
+     *
+     * @param item A DSpace item
+     * @param name The name of the bitstream
+     * @return The bitstream or null if none found.
+     */
+    private Bitstream findBitstreamByName(Item item, String name) throws SQLException
+    {
+        if (name == null || item == null)
+        {
+            return null;
+        }
+    
+        // Determine our the maximum number of directories that will be removed for a path.
+        int maxDepthPathSearch = 3;
+        if (ConfigurationManager.getProperty("xmlui.html.max-depth-guess") != null)
+        {
+            maxDepthPathSearch = ConfigurationManager.getIntProperty("xmlui.html.max-depth-guess");
+        }
+        
+        // Search for the named bitstream on this item. Each time through the loop
+        // a directory is removed from the name until either our maximum depth is
+        // reached or the bitstream is found. Note: an extra pass is added on to the
+        // loop for a last ditch effort where all directory paths will be removed.
+        for (int i = 0; i < maxDepthPathSearch+1; i++)
+        {
+                // Search through all the bitstreams and see
+                // if the name can be found
+                Bundle[] bundles = item.getBundles();
+                for (Bundle bundle : bundles)
+                {
+                    Bitstream[] bitstreams = bundle.getBitstreams();
+        
+                    for (Bitstream bitstream : bitstreams)
+                    {
+                        if (name.equals(bitstream.getName()))
+                        {
+                                return bitstream;
+                        }
+                    }
+                }
+                
+                // The bitstream was not found, so try removing a directory
+                // off of the name and see if we lost some path information.
+                int indexOfSlash = name.indexOf('/');
+                
+                if (indexOfSlash < 0)
+                {
+                    // No more directories to remove from the path, so return null for no
+                    // bitstream found.
+                    return null;
+                }
+               
+                name = name.substring(indexOfSlash+1);
+                
+                // If this is our next to last time through the loop then
+                // trim everything and only use the trailing filename.
+                if (i == maxDepthPathSearch-1)
+                {
+                        int indexOfLastSlash = name.lastIndexOf('/');
+                        if (indexOfLastSlash > -1)
+                        {
+                            name = name.substring(indexOfLastSlash + 1);
+                        }
+                }
+                
+        }
+        
+        // The named bitstream was not found and we exhausted the maximum path depth that
+        // we search.
+        return null;
+    }
+    
+    
+    /**
+         * Write the actual data out to the response.
+         *
+         * Some implementation notes:
+         *
+         * 1) We set a short expiration time just in the hopes of preventing someone
+         * from overloading the server by clicking reload a bunch of times. I
+         * Realize that this is nowhere near 100% effective but it may help in some
+         * cases and shouldn't hurt anything.
+         *
+         * 2) We accept partial downloads, thus if you lose a connection halfway
+         * through most web browser will enable you to resume downloading the
+         * bitstream.
+         */
+    public void generate() throws IOException, SAXException,
+            ProcessingException
+    {
+        if (this.bitstreamInputStream == null)
+        {
+            return;
+        }
+        
+        // Only allow If-Modified-Since protocol if request is from a spider
+        // since response headers would encourage a browser to cache results
+        // that might change with different authentication.
+        if (isSpider)
+        {
+            // Check for if-modified-since header -- ONLY if not authenticated
+            long modSince = request.getDateHeader("If-Modified-Since");
+            if (modSince != -1 && item != null && item.getLastModified().getTime() < modSince)
+            {
+                // Item has not been modified since requested date,
+                // hence bitstream has not been, either; return 304
+                response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+                return;
+            }
+        }
+
+        // Only set Last-Modified: header for spiders or anonymous
+        // access, since it might encourage browse to cache the result
+        // which might leave a result only available to authenticated
+        // users in the cache for a response later to anonymous user.
+        try
+        {
+            if (item != null && (isSpider || ContextUtil.obtainContext(request).getCurrentUser() == null))
+            {
+                // TODO:  Currently just borrow the date of the item, since
+                // we don't have last-mod dates for Bitstreams
+                response.setDateHeader("Last-Modified", item.getLastModified()
+                        .getTime());
+            }
+        }
+        catch (SQLException e)
+        {
+            throw new ProcessingException(e);
+        }
+
+        byte[] buffer = new byte[BUFFER_SIZE];
+        int length = -1;
+
+        // Only encourage caching if this is not a restricted resource, i.e.
+        // if it is accessed anonymously or is readable by Anonymous:
+        if (isAnonymouslyReadable)
+        {
+            response.setDateHeader("Expires", System.currentTimeMillis() + expires);
+        }
+        
+        // If this is a large bitstream then tell the browser it should treat it as a download.
+        int threshold = ConfigurationManager.getIntProperty("xmlui.content_disposition_threshold");
+        if (bitstreamSize > threshold && threshold != 0)
+        {
+                String name  = bitstreamName;
+                
+                // Try and make the download file name formatted for each browser.
+                try {
+                        String agent = request.getHeader("USER-AGENT");
+                        if (agent != null && agent.contains("MSIE"))
+                        {
+                            name = URLEncoder.encode(name, "UTF8");
+                        }
+                        else if (agent != null && agent.contains("Mozilla"))
+                        {
+                            name = MimeUtility.encodeText(name, "UTF8", "B");
+                        }
+                }
+                catch (UnsupportedEncodingException see)
+                {
+                        // do nothing
+                }
+                response.setHeader("Content-Disposition", "attachment;filename=" + '"' + name + '"');
+        }
+
+        ByteRange byteRange = null;
+
+        // Turn off partial downloads, they cause problems
+        // and are only rarely used. Specifically some windows pdf
+        // viewers are incapable of handling this request. You can
+        // uncomment the following lines to turn this feature back on.
+
+        // KRG turning this feature back on for video playback support in 
+        // VTechWorks
+
+        response.setHeader("Accept-Ranges", "bytes");
+        String ranges = request.getHeader("Range");
+        if (ranges != null)
+        {
+            try
+            {
+                ranges = ranges.substring(ranges.indexOf('=') + 1);
+                byteRange = new ByteRange(ranges);
+            }
+            catch (NumberFormatException e)
+            {
+                byteRange = null;
+                if (response instanceof HttpResponse)
+                {
+                    // Respond with status 416 (Request range not
+                    // satisfiable)
+                    response.setStatus(416);
+                }
+            }
+        }
+
+        try
+        {
+            if (byteRange != null)
+            {
+                String entityLength;
+                String entityRange;
+                ByteRange requestedRange = null; // V.T.
+
+                if (this.bitstreamSize != -1)
+                {
+                    entityLength = "" + this.bitstreamSize;
+                   
+                    /* entityRange = byteRange.intersection(
+                            new ByteRange(0, this.bitstreamSize)).toString(); */
+                    
+                    // this code fixes off by 1 error in commented line above
+                    requestedRange = byteRange.intersection(
+                                 new ByteRange(0, this.bitstreamSize - 1));
+                    entityRange = requestedRange.toString();
+                }
+                else
+                {
+                    entityLength = "*";
+                    entityRange = byteRange.toString();
+                }
+
+                //response.setHeader("Content-Range", entityRange + "/" + entityLength);
+                // V.T. fix for headers
+                response.setHeader("Content-Length","" 
+                                   + requestedRange.length());
+                response.setHeader("Content-Range", 
+                                "bytes " + entityRange + "/" + entityLength);
+
+                if (response instanceof HttpResponse)
+                {
+                    // Response with status 206 (Partial content)
+                    response.setStatus(206);
+                }
+
+                int pos = 0;
+                int posEnd;
+                while ((length = this.bitstreamInputStream.read(buffer)) > -1)
+                {
+                    posEnd = pos + length - 1;
+                    ByteRange intersection = byteRange.intersection(new ByteRange(pos, posEnd));
+                    if (intersection != null)
+                    {
+                        out.write(buffer, (int) intersection.getStart() - pos, (int) intersection.length());
+                    }
+                    pos += length;
+                }
+            }
+            else
+            {
+                response.setHeader("Content-Length", String.valueOf(this.bitstreamSize));
+
+                while ((length = this.bitstreamInputStream.read(buffer)) > -1)
+                {
+                    out.write(buffer, 0, length);
+                }
+                out.flush();
+            }
+        }
+        finally
+        {
+            try
+            {
+                // Close the bitstream input stream so that we don't leak a file descriptor
+                this.bitstreamInputStream.close();
+                
+                // Close the output stream as per Cocoon docs: http://cocoon.apache.org/2.2/core-modules/core/2.2/681_1_1.html
+                out.close();
+            } 
+            catch (IOException ioe)
+            {
+                // Closing the stream threw an IOException but do we want this to propagate up to Cocoon?
+                // No point since the user has already got the bitstream contents.
+                log.warn("Caught IO exception when closing a stream: " + ioe.getMessage());
+            }
+        }
+
+    }
+
+    /**
+     * Returns the mime-type of the bitstream.
+     */
+    public String getMimeType()
+    {
+        return this.bitstreamMimeType;
+    }
+    
+    /**
+         * Recycle
+         */
+    public void recycle() {
+        this.response = null;
+        this.request = null;
+        this.bitstreamInputStream = null;
+        this.bitstreamSize = 0;
+        this.bitstreamMimeType = null;
+    }
+
+
+}

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceCocoonServletFilter.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/cocoon/DSpaceCocoonServletFilter.java
@@ -1,0 +1,307 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.cocoon;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.SocketException;
+import java.net.URL;
+import java.net.URLConnection;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.log4j.Logger;
+import org.dspace.app.xmlui.configuration.XMLUIConfiguration;
+import org.dspace.app.xmlui.utils.AuthenticationUtil;
+import org.dspace.app.xmlui.utils.ContextUtil;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.harvest.OAIHarvester;
+
+/**
+ * This is a wrapper servlet around the cocoon servlet that performs two functions, 1) it 
+ * initializes DSpace / XML UI configuration parameters, and 2) it will perform interrupted 
+ * request resumption.
+ * 
+ * @author Scott Phillips
+ */
+public class DSpaceCocoonServletFilter implements Filter 
+{
+    private static final Logger LOG = Logger.getLogger(DSpaceCocoonServletFilter.class);
+	
+	private static final long serialVersionUID = 1L;
+	
+	
+    /**
+     * The DSpace config paramater, this is where the path to the DSpace
+     * configuration file can be obtained
+     */
+    public static final String DSPACE_CONFIG_PARAMETER = "dspace-config";
+	
+    /**
+     * This method holds code to be removed in the next version 
+     * of the DSpace XMLUI, it is now managed by a Shared Context 
+     * Listener in the dspace-api project. 
+     * 
+     * It is deprecated, rather than removed to maintain backward 
+     * compatibility for local DSpace 1.5.x customized overlays.
+     * 
+     * TODO: Remove in trunk
+     *
+     * @deprecated Use Servlet Context Listener provided 
+     * in dspace-api (remove in > 1.5.x)
+     * @throws ServletException
+     */
+    private void initDSpace(FilterConfig arg0) throws ServletException
+    {
+        // On Windows, URL caches can cause problems, particularly with undeployment
+        // So, here we attempt to disable them if we detect that we are running on Windows
+        try
+        {
+            String osName = System.getProperty("os.name");
+            if (osName != null)
+            {
+                osName = osName.toLowerCase();
+            }
+
+            if (osName != null && osName.contains("windows"))
+            {
+                URL url = new URL("http://localhost/");
+                URLConnection urlConn = url.openConnection();
+                urlConn.setDefaultUseCaches(false);
+            }
+        }
+        // Any errors thrown in disabling the caches aren't significant to
+        // the normal execution of the application, so we ignore them
+        catch (RuntimeException e)
+        {
+            LOG.error(e.getMessage(), e);
+        }
+        catch (Exception e)
+        {
+            LOG.error(e.getMessage(), e);
+        }
+        
+        /**
+         * Previous stages moved to shared ServletListener available in dspace-api
+         */
+        String dspaceConfig = null;
+        
+        /**
+         * Stage 1
+         * 
+         * Locate the dspace config
+         */
+        
+        // first check the local per-webapp parameter, then check the global parameter.
+        dspaceConfig = arg0.getInitParameter(DSPACE_CONFIG_PARAMETER);
+        if (dspaceConfig == null)
+        {
+            dspaceConfig = arg0.getServletContext().getInitParameter(DSPACE_CONFIG_PARAMETER);
+        }
+        
+        // Finally, if no config parameter found throw an error
+        if (dspaceConfig == null || "".equals(dspaceConfig))
+        {
+            throw new ServletException(
+                    "\n\nDSpace has failed to initialize. This has occurred because it was unable to determine \n" +
+                    "where the dspace.cfg file is located. The path to the configuration file should be stored \n" +
+                    "in a context variable, '"+DSPACE_CONFIG_PARAMETER+"', in either the local servlet or global contexts. \n" +
+                    "No context variable was found in either location.\n\n");
+        }
+            
+        /**
+         * Stage 2
+         * 
+         * Load the dspace config. Also may load log4j configuration.
+         * (Please rely on ConfigurationManager or Log4j to configure logging)
+         * 
+         */
+        try 
+        {
+            if(!ConfigurationManager.isConfigured())
+            {
+                // Load in DSpace config
+                ConfigurationManager.loadConfig(dspaceConfig);
+            }
+            
+            
+        }
+        catch (RuntimeException e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+        {
+            throw new ServletException(
+                    "\n\nDSpace has failed to initialize, during stage 2. Error while attempting to read the \n" +
+                    "DSpace configuration file (Path: '"+dspaceConfig+"'). \n" +
+                    "This has likely occurred because either the file does not exist, or its permissions \n" +
+                    "are set incorrectly, or the path to the configuration file is incorrect. The path to \n" +
+                    "the DSpace configuration file is stored in a context variable, 'dspace-config', in \n" +
+                    "either the local servlet or global context.\n\n",e);
+        }
+    }
+    
+    /**
+     * Before this servlet will become functional replace 
+     */
+    public void init(FilterConfig arg0) throws ServletException {
+
+        this.initDSpace(arg0);
+        
+    	// Paths to the various config files
+    	String webappConfigPath    = null;
+    	String installedConfigPath = null;
+             	            
+        /**
+         * Stage 3
+         * 
+         * Load the XML UI configuration
+         */
+    	try
+    	{
+    		// There are two places we could find the XMLUI configuration, 
+    		// 1) inside the webapp's WEB-INF directory, or 2) inside the 
+    		// installed dspace config directory along side the dspace.cfg.
+    		
+    		webappConfigPath = arg0.getServletContext().getRealPath("/") 
+    				+ File.separator + "WEB-INF" + File.separator + "xmlui.xconf";
+    		
+    		installedConfigPath = ConfigurationManager.getProperty("dspace.dir")
+	                + File.separator + "config" + File.separator + "xmlui.xconf";
+    		
+	        XMLUIConfiguration.loadConfig(webappConfigPath,installedConfigPath);
+    	}   
+    	catch (RuntimeException e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+    	{
+    		throw new ServletException(
+    				"\n\nDSpace has failed to initialize, during stage 3. Error while attempting to read \n" +
+    				"the XML UI configuration file (Path: "+webappConfigPath+" or '"+installedConfigPath+"').\n" + 
+    				"This has likely occurred because either the file does not exist, or its permissions \n" +
+    				"are set incorrectly, or the path to the configuration file is incorrect. The XML UI \n" +
+    				"configuration file should be named \"xmlui.xconf\" and located inside the standard \n" +
+    				"DSpace configuration directory. \n\n",e);
+    	}
+   
+		if (ConfigurationManager.getBooleanProperty("oai", "harvester.autoStart"))
+    	{
+    		try {
+    			OAIHarvester.startNewScheduler();
+    		}
+            catch (RuntimeException e)
+            {
+                LOG.error(e.getMessage(), e);
+            }
+    		catch (Exception e)
+    		{
+                LOG.error(e.getMessage(), e);
+    		}
+    	}
+    	
+    }
+    
+	
+	/**
+     * Before passing off a request to the cocoon servlet check to see if there is a request that 
+     * should be resumed? If so replace the real request with a faked request and pass that off to 
+     * cocoon.
+     */
+	public void doFilter(ServletRequest request, ServletResponse response,
+			FilterChain arg2) throws IOException, ServletException { 
+    
+            HttpServletRequest realRequest = (HttpServletRequest)request;
+            HttpServletResponse realResponse = (HttpServletResponse) response;
+
+            try {
+	    	// Check if there is a request to be resumed.
+	        realRequest = AuthenticationUtil.resumeRequest(realRequest);
+	
+	        // Send the real request or the resumed request off to
+	        // cocoon....right after we check our URL...
+	
+                // Get the Request URI, this will include the Context Path
+                String requestUri = realRequest.getRequestURI();
+                // Get the Context Path of the XMLUI web application
+                String contextPath = realRequest.getContextPath();
+                // Remove the Context Path from the Request URI -- this is the URI within our webapp
+                String uri = requestUri.replace(contextPath, "");
+                
+                // If the URI within XMLUI is an empty string, this means user 
+                // accessed XMLUI homepage *without* a trailing slash
+                if(uri==null || uri.length()==0)
+                {
+                    // Redirect the user to XMLUI homepage with a trailing slash
+                    // (This is necessary to ensure our Session Cookie, which ends 
+                    // in a trailing slash, isn't lost by some browsers, e.g. IE)
+                    String locationWithTrailingSlash = realRequest.getRequestURI() + "/";
+                    
+                    // Reset any existing response headers -- instead we are going to redirect user to correct path
+                    realResponse.reset();
+                    
+                    // Redirect user to homepage with trailing slash
+                    realResponse.sendRedirect(locationWithTrailingSlash);
+                }    
+	        // if force ssl is on and the user has authenticated and the request is not secure redirect to https
+                else if ((ConfigurationManager.getBooleanProperty("xmlui.force.ssl"))
+                        && (AuthenticationUtil.isLoggedIn(realRequest))
+                        && (!realRequest.isSecure()))
+                {
+                    StringBuffer location = new StringBuffer("https://");
+                    location.append(ConfigurationManager.getProperty("dspace.hostname"))
+                        .append(realRequest.getRequestURI())
+                            .append(realRequest.getQueryString() == null ? ""
+                                    : ("?" + realRequest.getQueryString()));
+                    realResponse.sendRedirect(location.toString());
+	        }
+                else
+                {   // invoke the next filter
+                    arg2.doFilter(realRequest, realResponse);
+                }
+    } catch (IOException e) {
+        ContextUtil.abortContext(realRequest);
+        if (LOG.isDebugEnabled()) {
+              LOG.debug("The connection was reset", e);
+            
+              // KRG Change required log level to debug
+              LOG.debug("Client closed the connection before file download was complete");
+        }
+
+    } catch (RuntimeException e) {
+        ContextUtil.abortContext(realRequest);
+        LOG.error("Serious Runtime Error Occurred Processing Request!", e);
+        throw e;
+	} catch (Exception e) {
+	    ContextUtil.abortContext(realRequest);
+            // KRG change debug info for clientabort, http partial byte request
+            LOG.error("Serious Error Occurred Processing Request: " + 
+                        e.getClass().getName() );
+	} finally {
+	    // Close out the DSpace context no matter what.
+	    ContextUtil.completeContext(realRequest);
+	}
+    }
+
+	public void destroy() {
+		// TODO Auto-generated method stub
+		
+	}
+
+
+
+}

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -1514,6 +1514,7 @@
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Content Files (default)</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Metadata Files</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Thumbnails</message>
+        <message key="xmlui.administrative.item.AddBitstreamForm.bundle.MOVIEPOSTER">Movie Posters</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Licenses</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">Creative Commons Licenses</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">File</message>


### PR DESCRIPTION
This resolves issue #31 - recreate video playback feature

This change includes:

   - Changes to the bitstream format registry to add mp4,webm,webvtt files

   - Changes to local i18n messages and dspace.cfg to allow upload of
     large movieposter preview frame in viewer (in MOVIEPOSTER bundle)

   - A modified bitstream reader servlet to allow partial byte requests for
     video streaming

   - Changes to logging in the Cocoon servlet filter to accommodate partial
     byte requests

   - Changes in VTMirage2 theme to detect items with (BOTH!) mp4 and
     webm files to display an inline video player with detection and support
     for webvtt caption files (in CONTENT/ORIGINAL bundle)

The aspect ratio of the viewer has been changed from the previous Virginia Tech
implementation to be a better fit for our newer video files.

These changes have been placed in maven overlays.