### PR TITLE
#25

### DIFF
--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -233,7 +233,11 @@
             <artifactId>servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
-
+    	<dependency>
+			<groupId>org.jsoup</groupId>
+    		<artifactId>jsoup</artifactId>
+    		<version>1.8.3</version>
+    	</dependency>
     </dependencies>
 
 </project>

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/XSLUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/XSLUtils.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.xmlui.utils;
 
+import org.jsoup.Jsoup;
+
 /**
  * Utilities that are needed in XSL transformations.
  *
@@ -52,5 +54,20 @@ public class XSLUtils {
 
         return string.substring(0, targetLength) + " ...";
 
+    }
+    
+    /*
+     * Remove html tags from String
+     */
+    public static String htmlToText(String htmlString) {
+    	return Jsoup.parse(htmlString).text();
+    }
+    
+    /*
+     * Remove html tags from String, and Cuts off the string at the space nearest to the targetLength if there is one within
+     * maxDeviation chars from the targetLength, or at the targetLength if no such space is found
+     */
+    public static String htmlToShortString(String htmlString, int targetLength, int maxDeviation) {
+    	return shortenString(htmlToText(htmlString), targetLength, maxDeviation);
     }
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-list.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-list.xsl
@@ -1,0 +1,319 @@
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+
+<!--
+    Rendering of a list of items (e.g. in a search or
+    browse results page)
+
+    Author: art.lowel at atmire.com
+    Author: lieven.droogmans at atmire.com
+    Author: ben at atmire.com
+    Author: Alexey Maslov
+
+-->
+
+<xsl:stylesheet
+    xmlns:i18n="http://apache.org/cocoon/i18n/2.1"
+    xmlns:dri="http://di.tamu.edu/DRI/1.0/"
+    xmlns:mets="http://www.loc.gov/METS/"
+    xmlns:dim="http://www.dspace.org/xmlns/dspace/dim"
+    xmlns:xlink="http://www.w3.org/TR/xlink/"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:atom="http://www.w3.org/2005/Atom"
+    xmlns:ore="http://www.openarchives.org/ore/terms/"
+    xmlns:oreatom="http://www.openarchives.org/ore/atom/"
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:xalan="http://xml.apache.org/xalan"
+    xmlns:encoder="xalan://java.net.URLEncoder"
+    xmlns:util="org.dspace.app.xmlui.utils.XSLUtils"
+    xmlns:confman="org.dspace.core.ConfigurationManager"
+    exclude-result-prefixes="xalan encoder i18n dri mets dim xlink xsl util confman">
+
+    <xsl:output indent="yes"/>
+
+    <!--these templates are modfied to support the 2 different item list views that
+    can be configured with the property 'xmlui.theme.mirage.item-list.emphasis' in dspace.cfg-->
+
+    <xsl:template name="itemSummaryList-DIM">
+        <xsl:variable name="itemWithdrawn" select="./mets:dmdSec/mets:mdWrap[@OTHERMDTYPE='DIM']/mets:xmlData/dim:dim/@withdrawn" />
+
+        <xsl:variable name="href">
+            <xsl:choose>
+                <xsl:when test="$itemWithdrawn">
+                    <xsl:value-of select="@OBJEDIT"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="@OBJID"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
+        <xsl:variable name="emphasis" select="confman:getProperty('xmlui.theme.mirage.item-list.emphasis')"/>
+        <xsl:choose>
+            <xsl:when test="'file' = $emphasis">
+
+
+                <div class="item-wrapper row">
+                    <div class="col-sm-3 hidden-xs">
+                        <xsl:apply-templates select="./mets:fileSec" mode="artifact-preview">
+                            <xsl:with-param name="href" select="$href"/>
+                        </xsl:apply-templates>
+                    </div>
+
+                    <div class="col-sm-9">
+                        <xsl:apply-templates select="./mets:dmdSec/mets:mdWrap[@OTHERMDTYPE='DIM']/mets:xmlData/dim:dim"
+                                             mode="itemSummaryList-DIM-metadata">
+                            <xsl:with-param name="href" select="$href"/>
+                        </xsl:apply-templates>
+                    </div>
+
+                </div>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="./mets:dmdSec/mets:mdWrap[@OTHERMDTYPE='DIM']/mets:xmlData/dim:dim"
+                                     mode="itemSummaryList-DIM-metadata"><xsl:with-param name="href" select="$href"/></xsl:apply-templates>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!--handles the rendering of a single item in a list in file mode-->
+    <!--handles the rendering of a single item in a list in metadata mode-->
+    <xsl:template match="dim:dim" mode="itemSummaryList-DIM-metadata">
+        <xsl:param name="href"/>
+        <div class="artifact-description">
+            <h4 class="artifact-title">
+                <xsl:element name="a">
+                    <xsl:attribute name="href">
+                        <xsl:value-of select="$href"/>
+                    </xsl:attribute>
+                    <xsl:choose>
+                        <xsl:when test="dim:field[@element='title']">
+                            <xsl:value-of select="dim:field[@element='title'][1]/node()"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <i18n:text>xmlui.dri2xhtml.METS-1.0.no-title</i18n:text>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:element>
+                <span class="Z3988">
+                    <xsl:attribute name="title">
+                        <xsl:call-template name="renderCOinS"/>
+                    </xsl:attribute>
+                    &#xFEFF; <!-- non-breaking space to force separating the end tag -->
+                </span>
+            </h4>
+            <div class="artifact-info">
+                <span class="author h4">
+                    <small>
+                    <xsl:choose>
+                        <xsl:when test="dim:field[@element='contributor'][@qualifier='author']">
+                            <xsl:for-each select="dim:field[@element='contributor'][@qualifier='author']">
+                                <span>
+                                  <xsl:if test="@authority">
+                                    <xsl:attribute name="class"><xsl:text>ds-dc_contributor_author-authority</xsl:text></xsl:attribute>
+                                  </xsl:if>
+                                  <xsl:copy-of select="node()"/>
+                                </span>
+                                <xsl:if test="count(following-sibling::dim:field[@element='contributor'][@qualifier='author']) != 0">
+                                    <xsl:text>; </xsl:text>
+                                </xsl:if>
+                            </xsl:for-each>
+                        </xsl:when>
+                        <xsl:when test="dim:field[@element='creator']">
+                            <xsl:for-each select="dim:field[@element='creator']">
+                                <xsl:copy-of select="node()"/>
+                                <xsl:if test="count(following-sibling::dim:field[@element='creator']) != 0">
+                                    <xsl:text>; </xsl:text>
+                                </xsl:if>
+                            </xsl:for-each>
+                        </xsl:when>
+                        <xsl:when test="dim:field[@element='contributor']">
+                            <xsl:for-each select="dim:field[@element='contributor']">
+                                <xsl:copy-of select="node()"/>
+                                <xsl:if test="count(following-sibling::dim:field[@element='contributor']) != 0">
+                                    <xsl:text>; </xsl:text>
+                                </xsl:if>
+                            </xsl:for-each>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <i18n:text>xmlui.dri2xhtml.METS-1.0.no-author</i18n:text>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                    </small>
+                </span>
+                <xsl:text> </xsl:text>
+                <xsl:if test="dim:field[@element='date' and @qualifier='issued']">
+	                <span class="publisher-date h4">  <small>
+	                    <xsl:text>(</xsl:text>
+	                    <xsl:if test="dim:field[@element='publisher']">
+	                        <span class="publisher">
+	                            <xsl:copy-of select="dim:field[@element='publisher']/node()"/>
+	                        </span>
+	                        <xsl:text>, </xsl:text>
+	                    </xsl:if>
+	                    <span class="date">
+	                        <xsl:value-of select="substring(dim:field[@element='date' and @qualifier='issued']/node(),1,10)"/>
+	                    </span>
+	                    <xsl:text>)</xsl:text>
+                        </small></span>
+                </xsl:if>
+            </div>
+            <xsl:if test="dim:field[@element = 'description' and @qualifier='abstract']">
+                <xsl:variable name="abstract" select="dim:field[@element = 'description' and @qualifier='abstract']/node()"/>
+                <div class="artifact-abstract">
+                	<!-- remove html tags from abstract field in the item list view -->
+                	<!--
+                    <xsl:value-of select="util:shortenString($abstract, 220, 10)"/>
+                    -->
+                    <xsl:value-of select="util:htmlToShortString($abstract, 220, 10)"/>
+                    
+                </div>
+            </xsl:if>
+        </div>
+    </xsl:template>
+
+    <xsl:template name="itemDetailList-DIM">
+        <xsl:call-template name="itemSummaryList-DIM"/>
+    </xsl:template>
+
+
+    <xsl:template match="mets:fileSec" mode="artifact-preview">
+        <xsl:param name="href"/>
+        <div class="thumbnail artifact-preview">
+            <a class="image-link" href="{$href}">
+                <xsl:choose>
+                    <xsl:when test="mets:fileGrp[@USE='THUMBNAIL']">
+                        <img class="img-responsive" alt="xmlui.mirage2.item-list.thumbnail" i18n:attr="alt">
+                            <xsl:attribute name="src">
+                                <xsl:value-of
+                                        select="mets:fileGrp[@USE='THUMBNAIL']/mets:file/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                            </xsl:attribute>
+                        </img>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <img alt="xmlui.mirage2.item-list.thumbnail" i18n:attr="alt">
+                            <xsl:attribute name="data-src">
+                                <xsl:text>holder.js/100%x</xsl:text>
+                                <xsl:value-of select="$thumbnail.maxheight"/>
+                                <xsl:text>/text:No Thumbnail</xsl:text>
+                            </xsl:attribute>
+                        </img>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </a>
+        </div>
+    </xsl:template>
+
+
+
+
+    <!--
+        Rendering of a list of items (e.g. in a search or
+        browse results page)
+
+        Author: art.lowel at atmire.com
+        Author: lieven.droogmans at atmire.com
+        Author: ben at atmire.com
+        Author: Alexey Maslov
+
+    -->
+
+
+
+        <!-- Generate the info about the item from the metadata section -->
+        <xsl:template match="dim:dim" mode="itemSummaryList-DIM">
+            <xsl:variable name="itemWithdrawn" select="@withdrawn" />
+            <div class="artifact-description">
+                <div class="artifact-title">
+                    <xsl:element name="a">
+                        <xsl:attribute name="href">
+                            <xsl:choose>
+                                <xsl:when test="$itemWithdrawn">
+                                    <xsl:value-of select="ancestor::mets:METS/@OBJEDIT" />
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:value-of select="ancestor::mets:METS/@OBJID" />
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:attribute>
+                        <xsl:choose>
+                            <xsl:when test="dim:field[@element='title']">
+                                <xsl:value-of select="dim:field[@element='title'][1]/node()"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.no-title</i18n:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:element>
+                </div>
+                <span class="Z3988">
+                    <xsl:attribute name="title">
+                        <xsl:call-template name="renderCOinS"/>
+                    </xsl:attribute>
+                    &#xFEFF; <!-- non-breaking space to force separating the end tag -->
+                </span>
+                <div class="artifact-info">
+                    <span class="author">
+                        <xsl:choose>
+                            <xsl:when test="dim:field[@element='contributor'][@qualifier='author']">
+                                <xsl:for-each select="dim:field[@element='contributor'][@qualifier='author']">
+                                    <span>
+                                        <xsl:if test="@authority">
+                                            <xsl:attribute name="class"><xsl:text>ds-dc_contributor_author-authority</xsl:text></xsl:attribute>
+                                        </xsl:if>
+                                        <xsl:copy-of select="node()"/>
+                                    </span>
+                                    <xsl:if test="count(following-sibling::dim:field[@element='contributor'][@qualifier='author']) != 0">
+                                        <xsl:text>; </xsl:text>
+                                    </xsl:if>
+                                </xsl:for-each>
+                            </xsl:when>
+                            <xsl:when test="dim:field[@element='creator']">
+                                <xsl:for-each select="dim:field[@element='creator']">
+                                    <xsl:copy-of select="node()"/>
+                                    <xsl:if test="count(following-sibling::dim:field[@element='creator']) != 0">
+                                        <xsl:text>; </xsl:text>
+                                    </xsl:if>
+                                </xsl:for-each>
+                            </xsl:when>
+                            <xsl:when test="dim:field[@element='contributor']">
+                                <xsl:for-each select="dim:field[@element='contributor']">
+                                    <xsl:copy-of select="node()"/>
+                                    <xsl:if test="count(following-sibling::dim:field[@element='contributor']) != 0">
+                                        <xsl:text>; </xsl:text>
+                                    </xsl:if>
+                                </xsl:for-each>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.no-author</i18n:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </span>
+                    <xsl:text> </xsl:text>
+                    <xsl:if test="dim:field[@element='date' and @qualifier='issued'] or dim:field[@element='publisher']">
+                        <span class="publisher-date">
+                            <xsl:text>(</xsl:text>
+                            <xsl:if test="dim:field[@element='publisher']">
+                                <span class="publisher">
+                                    <xsl:copy-of select="dim:field[@element='publisher']/node()"/>
+                                </span>
+                                <xsl:text>, </xsl:text>
+                            </xsl:if>
+                            <span class="date">
+                                <xsl:value-of select="substring(dim:field[@element='date' and @qualifier='issued']/node(),1,10)"/>
+                            </span>
+                            <xsl:text>)</xsl:text>
+                        </span>
+                    </xsl:if>
+                </div>
+            </div>
+        </xsl:template>
+
+</xsl:stylesheet>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -253,7 +253,11 @@
                     <xsl:for-each select="dim:field[@element='description' and @qualifier='abstract']">
                         <xsl:choose>
                             <xsl:when test="node()">
+                                <!-- html encoding for abstracts -->
+                            	<!--
                                 <xsl:copy-of select="node()"/>
+                                -->
+                                <xsl:value-of select="node()" disable-output-escaping="yes" />
                             </xsl:when>
                             <xsl:otherwise>
                                 <xsl:text>&#160;</xsl:text>


### PR DESCRIPTION
Html encoding for abstract.
1. In the item list view, “abstract” only shows  plain text (html tags have been removed)
2. in the simple item record view, “abstract”  is rendered by html (If this abstact metadata contains html tags. e.g, show paragraphs, subscript, supscript, and so on)
3. in the full item record view, shows original html text ( so users can edit this field using html tags)