### PR TITLE
Create search facets

### DIFF
--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -46,6 +46,10 @@
                <!--Use site to override the default configuration for the home page & default discovery page-->
                <entry key="site" value-ref="homepageConfiguration" />
                <!--<entry key="123456789/7621" value-ref="defaultConfiguration"/>-->
+               <entry key="10919/5534" value-ref="etdConfiguration"/>
+               <entry key="10919/11041" value-ref="etdConfiguration"/>
+               <entry key="10919/9291" value-ref="etdConfiguration"/>
+               <entry key="10919/51287" value-ref="etdConfiguration"/>
             </map>
         </property>
         <property name="toIgnoreMetadataFields">
@@ -112,7 +116,6 @@
                 <ref bean="searchFilterIssued" />
                 <ref bean="searchFilterType" />          
                 <ref bean="searchFilterAbstract" />
-                <ref bean="searchFilterKeyword" />
                 <ref bean="searchFilterSeries" />
                 <ref bean="searchFilterIdentifier" />
                 <ref bean="searchFilterMime" />
@@ -215,6 +218,8 @@
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterType" />
+                <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterSubject" />
             </list>
         </property>
         <!-- Set TagCloud configuration per discovery configuration -->
@@ -228,7 +233,6 @@
                 <ref bean="searchFilterIssued" />
                 <ref bean="searchFilterType" />          
                 <ref bean="searchFilterAbstract" />
-                <ref bean="searchFilterKeyword" />
                 <ref bean="searchFilterSeries" />
                 <ref bean="searchFilterIdentifier" />
                 <ref bean="searchFilterMime" />
@@ -288,6 +292,122 @@
                         </bean>
                     </list>
                 </property>
+            </bean>
+        </property>
+        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
+        <property name="spellCheckEnabled" value="true"/>
+    </bean>
+    
+    <!--The ETD specific configuration settings for discovery-->
+    <bean id="etdConfiguration" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+        <!--Which sidebar facets are to be displayed-->
+        <property name="sidebarFacets">
+            <list>
+                <ref bean="searchFilterDepartment" />
+                <ref bean="searchFilterSubject" />
+                <ref bean="searchFilterAdvisor" />
+                <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterEtdlevel" />
+            </list>
+        </property>
+        <!-- Set TagCloud configuration per discovery configuration -->
+        <property name="tagCloudFacetConfiguration" ref="defaultTagCloudFacetConfiguration"/>
+        <!--The search filters which can be used on the discovery search page-->
+        <property name="searchFilters">
+            <list>
+                <ref bean="searchFilterTitle" />
+                <ref bean="searchFilterAuthor" />
+                <ref bean="searchFilterSubject" />
+                <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterType" />          
+                <ref bean="searchFilterAbstract" />
+                <ref bean="searchFilterIdentifier" />
+                <ref bean="searchFilterMime" />
+                <ref bean="searchFilterCoverage" />
+                <ref bean="searchFilterSponsor" />
+                <ref bean="searchFilterLanguage" />
+                <ref bean="searchFilterDepartment" />
+                <ref bean="searchFilterAdvisor" />
+                <ref bean="searchFilterEtdlevel" />
+            </list>
+        </property>
+        <!--The sort filters for the discovery search-->
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
+                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
+                <property name="defaultSortOrder" value="desc"/>
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortTitle" />
+                        <ref bean="sortDateIssued" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!--Any default filter queries, these filter queries will be used for all queries done by discovery for this configuration-->
+        <!--<property name="defaultFilterQueries">-->
+            <!--<list>-->
+                <!--Only find items-->
+                <!--<value>search.resourcetype:2</value>-->
+            <!--</list>-->
+        <!--</property>-->
+        <!--The configuration for the recent submissions-->
+        <property name="recentSubmissionConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
+                <property name="metadataSortField" value="dc.date.accessioned" />
+                <property name="type" value="date"/>
+                <property name="max" value="20"/>
+                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
+                <property name="useAsHomePage" value="false"/>
+            </bean>
+        </property>
+        <!--Default result per page  -->
+        <property name="defaultRpp" value="10" />
+        <property name="hitHighlightingConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
+                <property name="metadataFields">
+                    <list>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="dc.title"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="dc.contributor.author"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="dc.description.abstract"/>
+                            <property name="maxSize" value="250"/>
+                            <property name="snippets" value="2"/>
+                        </bean>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="fulltext"/>
+                            <property name="maxSize" value="250"/>
+                            <property name="snippets" value="2"/>
+                        </bean>
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="moreLikeThisConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoveryMoreLikeThisConfiguration">
+                <!--When altering this list also alter the "xmlui.Discovery.RelatedItems.help" key as it describes
+                the metadata fields below-->
+                <property name="similarityMetadataFields">
+                    <list>
+                        <value>dc.title</value>
+                        <value>dc.contributor.author</value>
+                        <value>dc.creator</value>
+                        <value>dc.subject</value>
+                    </list>
+                </property>
+                <!--The minimum number of matching terms across the metadata fields above before an item is found as related -->
+                <property name="minTermFrequency" value="5"/>
+                <!--The maximum number of related items displayed-->
+                <property name="max" value="3"/>
+                <!--The minimum word length below which words will be ignored-->
+                <property name="minWordLength" value="5"/>
             </bean>
         </property>
         <!-- When true a "did you mean" example will be displayed, value can be true or false -->
@@ -419,7 +539,7 @@
                 <value>dc.subject.mesh</value>
             </list>
         </property>
-        <property name="facetLimit" value="10"/>
+        <property name="facetLimit" value="5"/>
         <property name="sortOrder" value="COUNT"/>
         <property name="splitter" value="::"/>
     </bean>
@@ -443,7 +563,7 @@
             </list>
         </property>
         <property name="sortOrder" value="COUNT"/>
-        <property name="facetLimit" value="10"/>
+        <property name="facetLimit" value="5"/>
     </bean>
     
     <bean id="searchFilterAbstract" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
@@ -519,7 +639,7 @@
         </property>
     </bean>
 
-    <bean id="searchFilterDepartment" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+    <bean id="searchFilterDepartment" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
         <property name="indexFieldName" value="department"/>
         <property name="metadataFields">
             <list>
@@ -527,18 +647,22 @@
                 <value>thesis.degree.discipline</value>
             </list>
         </property>
+        <property name="sortOrder" value="COUNT"/>
+        <property name="facetLimit" value="5"/>
     </bean>
 
-    <bean id="searchFilterEtdlevel" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+    <bean id="searchFilterEtdlevel" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
         <property name="indexFieldName" value="etdlevel"/>
         <property name="metadataFields">
             <list>
                 <value>thesis.degree.level</value>
             </list>
         </property>
+        <property name="sortOrder" value="COUNT"/>
+        <property name="facetLimit" value="5"/>
     </bean>
 
-    <bean id="searchFilterAdvisor" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+    <bean id="searchFilterAdvisor" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
         <property name="indexFieldName" value="advisor"/>
         <property name="metadataFields">
             <list>
@@ -546,17 +670,8 @@
                 <value>dc.contributor.advisor</value>
             </list>
         </property>
-    </bean>
-
-    <bean id="searchFilterKeyword" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
-        <property name="indexFieldName" value="keyword"/>
-        <property name="metadataFields">
-            <list>
-                <value>dc.*</value>
-                <value>dc.*.*</value>
-		        <value>thesis.*.*</value>
-            </list>
-        </property>
+        <property name="sortOrder" value="COUNT"/>
+        <property name="facetLimit" value="5"/>
     </bean>
 
 

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -95,9 +95,10 @@
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>
-                <ref bean="searchFilterAuthor" />
-                <ref bean="searchFilterSubject" />
+                <ref bean="searchFilterType" />
                 <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterSubject" />
+                <ref bean="searchFilterAuthor" />
             </list>
         </property>
         <!-- Set TagCloud configuration per discovery configuration -->
@@ -109,6 +110,19 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterSubject" />
                 <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterType" />          
+                <ref bean="searchFilterAbstract" />
+                <ref bean="searchFilterKeyword" />
+                <ref bean="searchFilterSeries" />
+                <ref bean="searchFilterIdentifier" />
+                <ref bean="searchFilterMime" />
+                <ref bean="searchFilterCoverage" />
+                <ref bean="searchFilterSponsor" />
+                <ref bean="searchFilterLanguage" />
+                <ref bean="searchFilterTrnumber" />
+                <ref bean="searchFilterDepartment" />
+                <ref bean="searchFilterAdvisor" />
+                <ref bean="searchFilterEtdlevel" />
             </list>
         </property>
         <!--The sort filters for the discovery search-->
@@ -200,9 +214,9 @@
         <!--Which sidebar facets are to be displayed (same as defaultConfiguration above)-->
         <property name="sidebarFacets">
             <list>
-                <ref bean="searchFilterAuthor" />
-                <ref bean="searchFilterSubject" />
+                <ref bean="searchFilterType" />
                 <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterSubject" />
             </list>
         </property>
         <!-- Set TagCloud configuration per discovery configuration -->
@@ -214,6 +228,19 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterSubject" />
                 <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterType" />          
+                <ref bean="searchFilterAbstract" />
+                <ref bean="searchFilterKeyword" />
+                <ref bean="searchFilterSeries" />
+                <ref bean="searchFilterIdentifier" />
+                <ref bean="searchFilterMime" />
+                <ref bean="searchFilterCoverage" />
+                <ref bean="searchFilterSponsor" />
+                <ref bean="searchFilterLanguage" />
+                <ref bean="searchFilterTrnumber" />
+                <ref bean="searchFilterDepartment" />
+                <ref bean="searchFilterAdvisor" />
+                <ref bean="searchFilterEtdlevel" />
             </list>
         </property>
         <!--The sort filters for the discovery search (same as defaultConfiguration above)-->
@@ -366,6 +393,8 @@
         <property name="metadataFields">
             <list>
                 <value>dc.title</value>
+                <!-- jing pu 4/20 #341 add series metadata to title search -->
+                <value>dc.relation.ispartofseries</value>
             </list>
         </property>
     </bean>
@@ -386,7 +415,10 @@
         <property name="indexFieldName" value="subject"/>
         <property name="metadataFields">
             <list>
-                <value>dc.subject.*</value>
+                <value>dc.subject</value>
+                <value>dc.subject.cabt</value>
+                <value>dc.subject.lcsh</value>
+                <value>dc.subject.mesh</value>
             </list>
         </property>
         <property name="facetLimit" value="10"/>
@@ -404,6 +436,131 @@
         <property name="type" value="date"/>
         <property name="sortOrder" value="VALUE"/>
     </bean>
+
+    <bean id="searchFilterType" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="type"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.type.*</value>
+            </list>
+        </property>
+        <property name="sortOrder" value="COUNT"/>
+        <property name="facetLimit" value="10"/>
+    </bean>
+    
+    <bean id="searchFilterAbstract" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="abstract"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.description.abstract</value>
+                <value>dc.description.tableofcontents</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterIdentifier" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="identifier"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.identifier.*</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterLanguage" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="language"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.language.iso</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterSeries" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="series"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.relation.ispartofseries</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterMime" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="mime"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.format.mimetype</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterCoverage" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="coverage"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.coverage.*</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterSponsor" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="sponsor"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.description.sponsorship</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterTrnumber" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="trnumber"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.identifier.trnumber</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterDepartment" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="department"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.contributor.department</value>
+                <value>thesis.degree.discipline</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterEtdlevel" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="etdlevel"/>
+        <property name="metadataFields">
+            <list>
+                <value>thesis.degree.level</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterAdvisor" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="advisor"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.contributor.committeechair</value>
+                <value>dc.contributor.advisor</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterKeyword" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="keyword"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.*</value>
+                <value>dc.*.*</value>
+		        <value>thesis.*.*</value>
+            </list>
+        </property>
+    </bean>
+
 
     <!--Sort properties-->
     <bean id="sortTitle" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -215,8 +215,6 @@
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterType" />
-                <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterSubject" />
             </list>
         </property>
         <!-- Set TagCloud configuration per discovery configuration -->

--- a/dspace/modules/xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
@@ -37,6 +37,9 @@
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.date.issued">Date Issued</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dateIssued">Date Issued</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_type">Content Type</message>
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">ETD Advisor</message>
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_etdlevel">ETD Level</message>
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Department</message>
 
     <!-- Site Leve Recently Added Content -->
     <message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">Recently Added</message>

--- a/dspace/modules/xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+<catalogue xml:lang="en" xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xmlns="http://apache.org/cocoon/i18n/2.1">
+
+    <!--
+		The format used by all keys is as follows
+
+		xmlui.<Aspect>.<Java Class>.<name>
+
+		There are a few exceptions to this naming format,
+		1) Some general keys are in the xmlui.general namespace
+		   because they are used very frequently.
+		2) Some general keys which are specific to a particular aspect
+		   may be found at xmlui.<Aspect> without specifiying a
+		   particular java class.
+		-->
+
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
+
+
+
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.contributor.author_filter">Author</message>
+
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.subject_filter">Subject</message>
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.type_filter">Content Type</message>
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.date.issued">Date Issued</message>
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dateIssued">Date Issued</message>
+
+
+    <!-- Site Leve Recently Added Content -->
+    <message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">Recently Added</message>
+
+    <message key="xmlui.ArtifactBrowser.AbstractRecentSubmissionTransformer.recent_submissions_more">View more</message>
+    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.head">{0}: Recent submissions</message>
+    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.trail">Recent submissions</message>
+    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.recent.head">Recently added</message>
+
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_type_filter">Kind</message>
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_publisher_filter">Publisher</message>
+
+
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.ispartof">Parent</message>
+
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by">Group Results By</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.none">None</message>
+
+
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.publication_grp">Publication</message>
+
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.comm">Community</message>
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.coll">Collection</message>
+
+
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.relation.ispartofseries_filter">Series</message>
+
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.contributor.author_browse">Browsing by: Author</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.title_browse">Browsing by: Title</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.subject_browse">Browsing by: Subject</message>
+        
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.description.abstract_browse">Browsing by: Abstract</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_series_browse">Browsing by: Series</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_sponsor_browse">Browsing by: Sponsor</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_identifier_browse">Browsing by: Identifier</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_language_browse">Browsing by: Language (ISO)</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_keyword_browse">Browsing by: Keyword</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_taxon_browse">Browsing by: Scientific Name</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_contributor_browse">Browsing by: Contributor</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_creator_browse">Browsing by: Creator</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_subject_browse">Browsing by: Subject</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_description_browse">Browsing by: Description</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_relation_browse">Browsing by: Relation</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_mime_browse">Browsing by: Mime-Type</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_other_browse">Browsing by: Other Contributor</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_advisor_browse">Browsing by: Advisor</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_department_browse">Browsing by: Department</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dateissued_dt_browse">Browsing by: Issue date</message>
+
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Author</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.title">Title</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued">Date Issued</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.type">Content Type</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.keyword">Keyword</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.abstract">Abstract</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.department">Department</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.series">Series</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.mime">Mime-Type</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.sponsor">Sponsor</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.identifier">Identifier</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.language">Language (ISO)</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.coverage">Coverage</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.trnumber">Technical Report No.</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.etdlevel">ETD Level</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.advisor">ETD Advisor</message>
+
+
+    <message key="xmlui.dri2xhtml.structural.pagination-info.nototal">Now showing items {0}-{1}</message>
+
+    <message key="xmlui.Discovery.AbstractSearch.type_author">Filter by: Author</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Author</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author_filter">Author</message>
+    <message key="xmlui.Discovery.AbstractSearch.type_subject">Filter by: Subject</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject_filter">Subject</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued.year">Date Issued</message>
+
+
+    <message key="xmlui.Discovery.AbstractSearch.startswith">Starts with</message>
+    <message key="xmlui.Discovery.AbstractSearch.startswith.help">Or enter first few letters:</message>
+
+    <message key="xmlui.Discovery.AbstractSearch.sort_by.head">Sort Options:</message>
+    <message key="xmlui.Discovery.AbstractSearch.sort_by.relevance">Relevance</message>
+    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_desc">Title Desc</message>
+    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_desc">Issue Date Desc</message>
+
+    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_asc">Title Asc</message>
+    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_asc">Issue Date Asc</message>
+
+    <message key="xmlui.Discovery.AbstractSearch.rpp">Results Per Page:</message>
+
+
+    <message key="xmlui.Discovery.AbstractSearch.filters.controls.add-filter">Add Filter</message>
+    <message key="xmlui.Discovery.AbstractSearch.filters.controls.apply-filters">Apply</message>
+    <message key="xmlui.Discovery.AbstractSearch.filters.controls.remove-filter">Remove</message>
+    <message key="xmlui.Discovery.AbstractSearch.filters.controls.new-filters.head">New Filters:</message>
+    <message key="xmlui.Discovery.AbstractSearch.filters.controls.current-filters.head">Current Filters:</message>
+    <message key="xmlui.Discovery.AbstractSearch.filters.display">Add filters</message>
+
+    <message key="xmlui.discovery.SearchFacetFilter.no-results">No filter values found</message>
+
+    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.head">Discover</message>
+    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.view-more">... View More</message>
+
+
+    <message key="xmlui.Discovery.SimpleSearch.search_scope">Search</message>
+    <message key="xmlui.discovery.SimpleSearch.search_label">Search</message>
+    <message key="xmlui.Discovery.SimpleSearch.filter_head">Filters</message>
+    <message key="xmlui.Discovery.SimpleSearch.filter_help">Use filters to refine the search results.</message>
+
+    <message key="xmlui.Discovery.SimpleSearch.filter.contains">Contains</message>
+    <message key="xmlui.Discovery.SimpleSearch.filter.equals">Equals</message>
+    <message key="xmlui.Discovery.SimpleSearch.filter.authority">ID</message>
+	<message key="xmlui.Discovery.SimpleSearch.filter.notcontains">Not Contains</message>
+    <message key="xmlui.Discovery.SimpleSearch.filter.notequals">Not Equals</message>
+    <message key="xmlui.Discovery.SimpleSearch.filter.notauthority">Not ID</message>
+    
+    <message key="xmlui.Discovery.RelatedItems.head">Related items</message>
+    <message key="xmlui.Discovery.RelatedItems.help">Showing items related by title, author, creator and subject.</message>
+
+    <message key="xmlui.Discovery.AbstractSearch.head1_community">Showing {0} out of a total of {1} results for community: {2}. <span class="searchTime">({3} seconds)</span></message>
+   	<message key="xmlui.Discovery.AbstractSearch.head1_collection">Showing {0} out of a total of {1} results for collection: {2}. <span class="searchTime">({3} seconds)</span></message>
+   	<message key="xmlui.Discovery.AbstractSearch.head1_none">Showing {0} out of a total of {1} results. <span class="searchTime">({2} seconds)</span></message>
+
+    <message key="xmlui.Discovery.AbstractSearch.head2">Communities or Collections matching your query</message>
+   	<message key="xmlui.Discovery.AbstractSearch.head3">Items matching your query</message>
+
+   	<message key="xmlui.Discovery.SimpleSearch.did_you_mean">Did you mean: </message>
+
+</catalogue>

--- a/dspace/modules/xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
@@ -36,7 +36,7 @@
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.type_filter">Content Type</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.date.issued">Date Issued</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dateIssued">Date Issued</message>
-
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_type">Content Type</message>
 
     <!-- Site Leve Recently Added Content -->
     <message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">Recently Added</message>


### PR DESCRIPTION
This pull request is in response to issues #17, #33, and #35, and to items no. 15 and no. 16 on the Technology Backlog. 

It adds a set of search filters and facets for the ETD community and collections (handles 10919/5534, 10919/11041, 10919/9291, and 10919/51287.

It defines many more search filters and facets.

It changes the default filters and facets set.

It adds a set of search filters and facets for the home page and default advanced search page.

It reduces the number of items in each facet to 5.