### PR TITLE
Etd search config

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/navigation.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/navigation.xsl
@@ -44,6 +44,15 @@
     <!-- TODO: figure out why i18n tags break the go button -->
     <xsl:template match="dri:options">
         <div id="ds-options" class="word-break hidden-print">
+        	<!-- Added static links -->
+			<div>
+				<h2 class="ds-option-set-head h6">
+					<i18n:text>xmlui.static.header</i18n:text>
+				</h2>
+               	<div id="ds-feed-option" class="ds-option-set list-group">
+                   	<xsl:call-template name="addStaticLinks"/>
+               	</div>
+			</div>
             <xsl:if test="not(contains(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='URI'], 'discover'))">
                 <div id="ds-search-option" class="ds-option-set">
                     <!-- The form, complete with a text box and a button, all built from attributes referenced
@@ -136,6 +145,31 @@
 
             </xsl:if>
         </div>
+    </xsl:template>
+    
+    <!-- Add static page links to a list -->
+	<xsl:template name="addStaticLinks">
+		<a class="list-group-item">
+			<xsl:attribute name="href">
+				<xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath'][not(@qualifier)]"/>
+				<xsl:text>/page/about</xsl:text>
+			</xsl:attribute>
+			<xsl:text>About</xsl:text>
+		</a>
+		<a class="list-group-item">
+			<xsl:attribute name="href">
+				<xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath'][not(@qualifier)]"/>
+				<xsl:text>/page/policies</xsl:text>
+			</xsl:attribute>
+			<xsl:text>Policies</xsl:text>
+		</a>
+ 		<a class="list-group-item">
+			<xsl:attribute name="href">
+				<xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath'][not(@qualifier)]"/>
+				<xsl:text>/page/help</xsl:text>
+			</xsl:attribute>
+			<xsl:text>Help</xsl:text>
+		</a>
     </xsl:template>
 
     <!-- Add each RSS feed from meta to a list -->

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
@@ -272,9 +272,12 @@
             <xsl:variable name="page_title" select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='title'][last()]" />
             <title>
                 <xsl:choose>
+                	<!-- unneccessary, removed-->
+                	<!--  
                     <xsl:when test="starts-with($request-uri, 'page/about')">
                         <i18n:text>xmlui.mirage2.page-structure.aboutThisRepository</i18n:text>
                     </xsl:when>
+                    -->
                     <xsl:when test="not($page_title)">
                         <xsl:text>  </xsl:text>
                     </xsl:when>
@@ -336,7 +339,11 @@
                             <span class="icon-bar"></span>
                         </button>
 
+						<!-- changed home logo link  -->
+						<!--
                         <a href="{$context-path}/" class="navbar-brand">
+                        -->
+                        <a href="http://www.vt.edu/" class="navbar-brand">
                             <img src="{$theme-path}/images/DSpace-logo-line.svg" />
                         </a>
 
@@ -765,12 +772,15 @@
 
             <!-- Check for the custom pages -->
             <xsl:choose>
+            	<!-- unneccessary, removed -->
+            	<!--  
                 <xsl:when test="starts-with($request-uri, 'page/about')">
                     <div class="hero-unit">
                         <h1><i18n:text>xmlui.mirage2.page-structure.heroUnit.title</i18n:text></h1>
                         <p><i18n:text>xmlui.mirage2.page-structure.heroUnit.content</i18n:text></p>
                     </div>
                 </xsl:when>
+                -->
                 <!-- Otherwise use default handling of body -->
                 <xsl:otherwise>
                     <xsl:apply-templates />

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/preprocess/general.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/preprocess/general.xsl
@@ -108,7 +108,33 @@
                 <i18n:text catalogue="default">xmlui.general.dspace_home</i18n:text>
             </trail>
             <trail>
-                <xsl:text>About This Repository</xsl:text>
+                <xsl:text>About</xsl:text>
+            </trail>
+        </pageMeta>
+    </xsl:template>
+    
+    <!-- Added static pages -->
+	<xsl:template match="dri:pageMeta[dri:metadata[@element = 'request'][@qualifier = 'URI']/text() = 'page/policies']">
+        <pageMeta>
+            <xsl:call-template name="copy-attributes"/>
+            <xsl:apply-templates select="*[not(self::dri:trail)]"/>
+            <trail target="{$context-path}/">
+                <i18n:text catalogue="default">xmlui.general.dspace_home</i18n:text>
+            </trail>
+            <trail>
+                <xsl:text>Policies</xsl:text>
+            </trail>
+        </pageMeta>
+    </xsl:template>
+	<xsl:template match="dri:pageMeta[dri:metadata[@element = 'request'][@qualifier = 'URI']/text() = 'page/help']">
+        <pageMeta>
+            <xsl:call-template name="copy-attributes"/>
+            <xsl:apply-templates select="*[not(self::dri:trail)]"/>
+            <trail target="{$context-path}/">
+                <i18n:text catalogue="default">xmlui.general.dspace_home</i18n:text>
+            </trail>
+            <trail>
+                <xsl:text>Help</xsl:text>
             </trail>
         </pageMeta>
     </xsl:template>

--- a/dspace-xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace-xmlui/src/main/webapp/i18n/messages.xml
@@ -61,7 +61,9 @@
     <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Only authenticated users who are administrators may assume the login as another user.</message>
     <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">You may not assume the login as another administrator.</message>
 
-
+	<!-- Added Static pages group header -->
+	<message key="xmlui.static.header">VTechWorks</message>
+	
 	<!--
 		This section is for feed syndications (RSS, atom, etc)
 	-->
@@ -2490,13 +2492,19 @@
     <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
     <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
     <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
-
-    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+    
+ 	<!-- Added static pages tab title -->
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About</message>
+    <message key="xmlui.mirage2.page-structure.policiesThisRepository">Policies</message>
+    <message key="xmlui.mirage2.page-structure.helpThisRepository">Help</message>
+    
     <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
 
+	<!-- unneccessary, removed -->
+	<!--  
     <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
     <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
-
+	-->
     <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
 
     <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -285,9 +285,12 @@
             <xsl:variable name="page_title" select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='title']" />
             <title>
                 <xsl:choose>
+                        <!-- Unneccessary, removed -->
+                		<!--
                         <xsl:when test="starts-with($request-uri, 'page/about')">
                                 <xsl:text>About This Repository</xsl:text>
                         </xsl:when>
+                        -->
                         <xsl:when test="not($page_title)">
                             <i18n:text>xmlui.dri2xhtml.METS-1.0.no-title</i18n:text>
                         </xsl:when>
@@ -417,9 +420,12 @@
         <div id="ds-trail-wrapper">
             <ul id="ds-trail">
                 <xsl:choose>
+                	<!-- Unneccessary, removed -->
+                	<!--  
                     <xsl:when test="starts-with($request-uri, 'page/about')">
                          <xsl:text>About This Repository</xsl:text>
                     </xsl:when>
+                    -->
                     <xsl:when test="count(/dri:document/dri:meta/dri:pageMeta/dri:trail) = 0">
                         <li class="ds-trail-link first-link">-</li>
                     </xsl:when>
@@ -648,6 +654,8 @@
 
             <!-- Check for the custom pages -->
             <xsl:choose>
+            	<!-- Unneccessary, removed -->
+            	<!--  
                 <xsl:when test="starts-with($request-uri, 'page/about')">
                     <div>
                         <h1>About This Repository</h1>
@@ -655,9 +663,10 @@
                             add your own content to the title, trail, and body. If you wish to add additional pages, you
                             will need to create an additional xsl:when block and match the request-uri to whatever page
                             you are adding. Currently, static pages created through altering XSL are only available
-                            under the URI prefix of page/.</p>
+                            under the URI prefix of page/. </p>
                     </div>
                 </xsl:when>
+                -->
                 <!-- Otherwise use default handling of body -->
                 <xsl:otherwise>
                     <xsl:apply-templates />

--- a/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/dri2xhtml-alt/core/page-structure.xsl
@@ -244,9 +244,12 @@
             <xsl:variable name="page_title" select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='title']" />
             <title>
                 <xsl:choose>
+						<!-- Unneccessary, removed -->
+                		<!--
                         <xsl:when test="starts-with($request-uri, 'page/about')">
                                 <xsl:text>About This Repository</xsl:text>
                         </xsl:when>
+                        -->
                         <xsl:when test="not($page_title)">
                                 <xsl:text>  </xsl:text>
                         </xsl:when>
@@ -299,9 +302,12 @@
 
             <ul id="ds-trail">
                 <xsl:choose>
+                		<!-- Unneccessary, removed -->
+                		<!--
                         <xsl:when test="starts-with($request-uri, 'page/about')">
                             <xsl:text>About This Repository</xsl:text>
                         </xsl:when>
+                        -->
                         <xsl:when test="count(/dri:document/dri:meta/dri:pageMeta/dri:trail) = 0">
                                 <li class="ds-trail-link first-link"> - </li>
                         </xsl:when>
@@ -522,6 +528,8 @@
 
             <!-- Check for the custom pages -->
             <xsl:choose>
+            	<!-- Unneccessary, removed-->
+            	<!--  
                 <xsl:when test="starts-with($request-uri, 'page/about')">
                     <div>
                         <h1>About This Repository</h1>
@@ -532,6 +540,7 @@
                             under the URI prefix of page/.</p>
                     </div>
                 </xsl:when>
+                -->
                 <!-- Otherwise use default handling of body -->
                 <xsl:otherwise>
                     <xsl:apply-templates />

--- a/dspace-xmlui/src/main/webapp/themes/dri2xhtml/structural.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/dri2xhtml/structural.xsl
@@ -293,9 +293,12 @@
             <xsl:variable name="page_title" select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='title']" />
             <title>
                 <xsl:choose>
+                    <!-- Unneccessary, removed -->
+                	<!--
                     <xsl:when test="starts-with($request-uri, 'page/about')">
                         <xsl:text>About This Repository</xsl:text>
                     </xsl:when>
+                    -->
                     <xsl:when test="not($page_title) or (string-length($page_title) &lt; 1)">
                                 <i18n:text>xmlui.dri2xhtml.METS-1.0.no-title</i18n:text>
                         </xsl:when>
@@ -348,9 +351,12 @@
             
             <ul id="ds-trail">
                 <xsl:choose>
+                		<!-- Unneccessary, removed -->
+                		<!--  
                         <xsl:when test="starts-with($request-uri, 'page/about')">
                             <xsl:text>About This Repository</xsl:text>
                         </xsl:when>
+                        -->
                         <xsl:when test="count(/dri:document/dri:meta/dri:pageMeta/dri:trail) = 0">
                                 <li class="ds-trail-link first-link"> - </li>
                         </xsl:when>
@@ -578,6 +584,8 @@
             <!-- Check for the custom pages -->
 
             <xsl:choose>
+            	<!-- Unneccessary, removed -->
+            	<!--  
                 <xsl:when test="starts-with($request-uri, 'page/about')">
                     <div>
                         <h1>About This Repository</h1>
@@ -588,6 +596,7 @@
                             under the URI prefix of page/.</p>
                     </div>
                 </xsl:when>
+                -->
                 <!-- Otherwise use default handling of body -->
                 <xsl:otherwise>
                     <xsl:apply-templates />
@@ -713,6 +722,7 @@
             
             <!-- Once the search box is built, the other parts of the options are added -->
             <xsl:apply-templates />
+            
 
             <!-- DS-984 Add RSS Links to Options Box -->
             <xsl:if test="count(/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='feed']) != 0">
@@ -3492,8 +3502,6 @@
             </div>
         </xsl:for-each>
     </xsl:template>
-
-
 
     <!-- Add each RSS feed from meta to a list -->
     <xsl:template name="addRSSLinks">

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -102,8 +102,8 @@
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterType" />
-                <ref bean="searchFilterIssued" />
                 <ref bean="searchFilterSubject" />
+                <ref bean="searchFilterIssued" />
                 <ref bean="searchFilterAuthor" />
             </list>
         </property>
@@ -120,13 +120,12 @@
                 <ref bean="searchFilterAbstract" />
                 <ref bean="searchFilterSeries" />
                 <ref bean="searchFilterIdentifier" />
-                <ref bean="searchFilterMime" />
-                <ref bean="searchFilterCoverage" />
                 <ref bean="searchFilterSponsor" />
                 <ref bean="searchFilterLanguage" />
                 <ref bean="searchFilterTrnumber" />
                 <ref bean="searchFilterDepartment" />
                 <ref bean="searchFilterAdvisor" />
+                <ref bean="searchFilterCommitteemember" />
                 <ref bean="searchFilterEtdlevel" />
             </list>
         </property>
@@ -220,8 +219,8 @@
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterType" />
-                <ref bean="searchFilterIssued" />
                 <ref bean="searchFilterSubject" />
+                <ref bean="searchFilterIssued" />
             </list>
         </property>
         <!-- Set TagCloud configuration per discovery configuration -->
@@ -237,13 +236,12 @@
                 <ref bean="searchFilterAbstract" />
                 <ref bean="searchFilterSeries" />
                 <ref bean="searchFilterIdentifier" />
-                <ref bean="searchFilterMime" />
-                <ref bean="searchFilterCoverage" />
                 <ref bean="searchFilterSponsor" />
                 <ref bean="searchFilterLanguage" />
                 <ref bean="searchFilterTrnumber" />
                 <ref bean="searchFilterDepartment" />
                 <ref bean="searchFilterAdvisor" />
+                <ref bean="searchFilterCommitteemember" />
                 <ref bean="searchFilterEtdlevel" />
             </list>
         </property>
@@ -321,16 +319,14 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterSubject" />
                 <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterDepartment" />
+                <ref bean="searchFilterAdvisor" />
+                <ref bean="searchFilterCommitteemember" />
+                <ref bean="searchFilterEtdlevel" />
                 <ref bean="searchFilterType" />          
                 <ref bean="searchFilterAbstract" />
                 <ref bean="searchFilterIdentifier" />
-                <ref bean="searchFilterMime" />
-                <ref bean="searchFilterCoverage" />
-                <ref bean="searchFilterSponsor" />
                 <ref bean="searchFilterLanguage" />
-                <ref bean="searchFilterDepartment" />
-                <ref bean="searchFilterAdvisor" />
-                <ref bean="searchFilterEtdlevel" />
             </list>
         </property>
         <!--The sort filters for the discovery search-->
@@ -518,6 +514,15 @@
         </property>
     </bean>
 
+    <bean id="searchFilterCommitteemember" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="committeemember"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.contributor.committeemember</value>
+            </list>
+        </property>
+    </bean>
+    
     <bean id="searchFilterCoverage" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
         <property name="indexFieldName" value="coverage"/>
         <property name="metadataFields">
@@ -541,6 +546,7 @@
         <property name="metadataFields">
             <list>
                 <value>dc.language.iso</value>
+                <value>dc.language</value>
             </list>
         </property>
     </bean>
@@ -586,6 +592,7 @@
         <property name="metadataFields">
             <list>
                 <value>dc.title</value>
+                <value>dc.title.alternative</value>
                 <!-- jing pu 4/20 #341 add series metadata to title search -->
                 <value>dc.relation.ispartofseries</value>
             </list>
@@ -598,6 +605,7 @@
         <property name="metadataFields">
             <list>
                 <value>dc.contributor.committeechair</value>
+                <value>dc.contributor.committeecochair</value>
                 <value>dc.contributor.advisor</value>
             </list>
         </property>
@@ -659,6 +667,7 @@
                 <value>dc.subject.cabt</value>
                 <value>dc.subject.lcsh</value>
                 <value>dc.subject.mesh</value>
+                <value>dc.subject.other</value>
             </list>
         </property>
         <property name="facetLimit" value="5"/>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/core/page-structure.xsl
@@ -31,6 +31,9 @@
                 xmlns:dc="http://purl.org/dc/elements/1.1/"
                 xmlns:confman="org.dspace.core.ConfigurationManager"
                 exclude-result-prefixes="i18n dri mets xlink xsl dim xhtml mods dc confman">
+                
+	<!-- Import external templates -->
+	<xsl:import href="staticpages.xsl"/>
 
     <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
 
@@ -278,9 +281,21 @@
             <xsl:variable name="page_title" select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='title'][last()]" />
             <title>
                 <xsl:choose>
+                    <!-- Added satic page tab title -->
+                	<xsl:when test="starts-with($request-uri, 'page/about')">
+                        <i18n:text>xmlui.mirage2.page-structure.aboutThisRepository</i18n:text>
+                    </xsl:when>
+                    <xsl:when test="starts-with($request-uri, 'page/policies')">
+                        <i18n:text>xmlui.mirage2.page-structure.policiesThisRepository</i18n:text>
+                    </xsl:when>
+                    <xsl:when test="starts-with($request-uri, 'page/help')">
+                        <i18n:text>xmlui.mirage2.page-structure.helpThisRepository</i18n:text>
+                    </xsl:when>
+                	<!--
                     <xsl:when test="starts-with($request-uri, 'page/about')">
                         <i18n:text>xmlui.mirage2.page-structure.aboutThisRepository</i18n:text>
                     </xsl:when>
+                    -->
                     <xsl:when test="not($page_title)">
                         <xsl:text>  </xsl:text>
                     </xsl:when>
@@ -341,8 +356,12 @@
                             <span class="icon-bar"></span>
                             <span class="icon-bar"></span>
                         </button>
-
+						
+						<!-- Changed home logo link -->
+						<!-- 
                         <a href="{$context-path}/" class="navbar-brand">
+                        -->
+                        <a href="http://www.vt.edu" class="navbar-brand">
                             <img src="{$theme-path}/images/VT_white_cmyk_invt.png" />
                         </a>
 
@@ -755,10 +774,32 @@
 
             <!-- Check for the custom pages -->
             <xsl:choose>
+            	<!-- Add static page contents -->
                 <xsl:when test="starts-with($request-uri, 'page/about')">
                     <div class="hero-unit">
-                        <h1><i18n:text>xmlui.mirage2.page-structure.heroUnit.title</i18n:text></h1>
-                        <p><i18n:text>xmlui.mirage2.page-structure.heroUnit.content</i18n:text></p>
+                     	<xsl:call-template name="AboutStaticPage"/>
+                    	<!-- 
+                        <h1><i18n:text>xmlui.mirage2.page-structure.heroUnit.about.title</i18n:text></h1>
+                        <p><i18n:text>xmlui.mirage2.page-structure.heroUnit.about.content</i18n:text></p>
+                        -->
+                    </div>
+                </xsl:when>
+				<xsl:when test="starts-with($request-uri, 'page/policies')">
+                    <div class="hero-unit">
+                    	<xsl:call-template name="PoliciesStaticPage"/>
+                    	<!-- 
+                        <h1><i18n:text>xmlui.mirage2.page-structure.heroUnit.pol.title</i18n:text></h1>
+                        <p><i18n:text>xmlui.mirage2.page-structure.heroUnit.pol.content</i18n:text></p>
+                        -->
+                    </div>
+                </xsl:when>
+				<xsl:when test="starts-with($request-uri, 'page/help')">
+                    <div class="hero-unit">
+                    	<xsl:call-template name="HelpStaticPage"/>
+                    	<!--  
+                        <h1><i18n:text>xmlui.mirage2.page-structure.heroUnit.help.title</i18n:text></h1>
+                        <p><i18n:text>xmlui.mirage2.page-structure.heroUnit.help.content</i18n:text></p>
+                        -->
                     </div>
                 </xsl:when>
                 <!-- Otherwise use default handling of body -->
@@ -769,7 +810,6 @@
 
         </div>
     </xsl:template>
-
 
     <!-- Currently the dri:meta element is not parsed directly. Instead, parts of it are referenced from inside
         other elements (like reference). The blank template below ends the execution of the meta branch -->
@@ -898,5 +938,5 @@
             </li>
         </xsl:if>
     </xsl:template>
-
+    
 </xsl:stylesheet>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/core/staticpages.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/core/staticpages.xsl
@@ -1,0 +1,129 @@
+<xsl:stylesheet xmlns:i18n="http://apache.org/cocoon/i18n/2.1"
+                xmlns:dri="http://di.tamu.edu/DRI/1.0/"
+                xmlns:mets="http://www.loc.gov/METS/"
+                xmlns:xlink="http://www.w3.org/TR/xlink/"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+                xmlns:dim="http://www.dspace.org/xmlns/dspace/dim"
+                xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                xmlns:mods="http://www.loc.gov/mods/v3"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:confman="org.dspace.core.ConfigurationManager"
+                exclude-result-prefixes="i18n dri mets xlink xsl dim xhtml mods dc confman">
+
+    <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+
+	<xsl:template name="AboutStaticPage">
+		<h1>About VTechWorks</h1>
+		<p>
+			VTechWorks, Virginia Tech's open access institutional repository, publicizes and preserves the scholarly work of Virginia Tech faculty, 
+			students, and staff: journal articles, books, theses, dissertations, conference papers, slide presentations, technical reports, working 
+			papers, administrative documents, videos, images, data sets, and more. Most content is recent, published within the last 15 years, but 
+			there is also a great deal of older and historical content. The full text of all documents is available, often in PDF format, and all 
+			entries are indexed by search engines such as Google Scholar and Summon. Any member of the Virginia Tech community can upload material 
+			to VTechWorks.
+		</p>
+		<p>
+			VTechWorks supports a hierarchical structure composed of Communities and Collections. Communities include colleges, departments, research 
+			centers, institutes, or other entities. Communities contain Collections and sub-communities, and Collections hold the digital works.
+			VTechWorks was launched in 2012 and runs on the widely-used DSpace preservation platform. VTechWorks is managed by the Virginia Tech Libraries 
+			for the purpose of stewarding the intellectual output of the university in its land-grant mission to serve the Commonwealth of Virginia, 
+			the nation, and the world community through the discovery and dissemination of new knowledge.
+		</p>
+		
+		<h1>How VTechWorks benefits researchers</h1>
+		<p>
+			<ul style="list-style-type:square">
+				<li>Research in VTechWorks is widely disseminated, free to anyone in the world with an Internet connection.</li>
+				<li>Research in VTechWorks is easily discovered, since it is indexed in Google Scholar, WorldCat, the Virginia Tech website, and the Virginia Tech library's Summon </li>
+				<li>Research in VTechWorks has increased impact: many studies show that openly accessible research is more frequently cited by journalists and scholars than research published in journals and books that must be paid for.</li>
+				<li>Research in VTechWorks has a persistent, stable link ("handle") that won't change even when current servers are replaced, which makes it more reliable for others to cite and to share on social</li>
+				<li>Research in VTechWorks will be preserved by the University Libraries for decades or even centuries, unlike research posted on a personal web page or published by a company that might go out of</li>
+				<li>Research in VTechWorks is preserved even if a researcher leaves Virginia Tech, but it can always be posted or published elsewhere, since Virginia Tech does not claim any unnecessary or additional rights to the material.</li>
+			</ul>
+		</p>
+	</xsl:template>
+	
+	<xsl:template name="PoliciesStaticPage">
+		<h1>VTechWorks Policies, Procedures, and Guidelines</h1>
+		<h2>Content Policies</h2>
+		<h3>Criteria for works in VTechWorks </h3>
+		<p>
+			<ul style="list-style-type:square">
+				<li>The work is produced, submitted, or sponsored by Virginia Tech faculty, staff, administrators, alumni, or students.</li>
+				<li>The work is related to education, research, service, or extension activities, or the work has historical value to the Virginia Tech community</li>
+				<li>
+					The author/owner must be willing and able to grant Virginia Tech the non-exclusive right to preserve and provide online access to the work. 
+					The authors and copyright owners determine if their works will be in VTechWorks exclusively or will made available through additional online 
+					platforms.
+				</li>
+				<li>
+					The complete text, image, audio, or video of the work is stored in VTechWorks, even if the file is not publicly available. VTechWorks is a 
+					content repository and does not accept metadata-only records.
+				</li>
+				<li>The work is appropriate for inclusion in the Collection to which it is submitted.</li>
+				<li>The work exists in a recommended file format that will facilitate long-term access and preservation, although any digital format will be accepted.</li>
+				<li>If the work is part of a series, other works in the series should also be deposited so that VTechWorks can offer as full a set as possible.</li>
+				<li>The work is static content, not a live data stream.  It is not possible to execute files or run software through VTechWorks.</li>
+			</ul>
+		</p>
+
+		<h3>Types of content in VTechWorks </h3>
+		<p>Typed of content in VTechWorks include (but are not limited to) 
+			<ul style="list-style-type:square">
+				<li>Journal articles, pre-prints, and post-prints, i.e., versions of peer-reviewed articles accepted for publication</li>
+				<li>Books, including scholarly monographs, textbooks</li>
+				<li>Technical reports</li>
+				<li>White papers</li>
+				<li>Extension materials, e.g., content created by Virginia Cooperative Extension</li>
+				<li>Learning objects, e.g., modules, syllabi, lecture videos, etc.</li>
+				<li>Presentations, including lecture notes, slides, and videos of scholarly talks</li>
+				<li>Posters, e.g., digital files of posters that were presented at conferences or symposia</li>
+				<li>Conference proceedings, especially symposia hosted or sponsored by Virginia Tech</li>
+				<li>Creative endeavors including media, art, music</li>
+				<li>Performances, e.g., audio or video recordings of recitals, dramatic readings, and the like</li>
+				<li>Research and statistical data, including surveys, censuses, voting records, field recordings, management plans, and other etc.</li>
+				<li>
+					Administrative documents, including policies, rulings, official statements, strategic and operational plans, annual reports, 
+					newslettes, and other materials generated by colleges and departments that document the history and intellectual life of Virginia Tech
+				</li>
+				<li>News articles and press releases produced by University Relations or other Virginia Tech news outlets</li>
+				<li>Historical material and primary sources, including historic photographs, manuscripts, and rare books</li>
+			</ul> 
+		</p>
+		<h3>File size guidelines </h3>
+		<p>
+			VTechWorks does not currently place restrictions on file size or the number of files that can be deposited. However, VTechWorks reserves the 
+			right to refuse to ingest materials whose volume would present a strain on its resources. In many cases, grant- or department-funded projects 
+			provide a budget for storage, preservation and access; in these cases, VTechWorks may be able to provide more storage for a nominal fee.
+		</p>
+
+
+	</xsl:template>
+	
+	<xsl:template name="HelpStaticPage">
+		<h1>VTechWorks Help</h1>
+		<p>
+			<ul style="list-style-type:square">
+				<li>
+					Ask library staff to help with determining the rights status of your scholarly work, with creating accounts and collections, and more at 
+					<a>
+						<xsl:attribute name="href">
+							<xsl:text>http://j.mp/vtechworks-service</xsl:text>
+						</xsl:attribute>
+						<xsl:text>http://j.mp/vtechworks-service</xsl:text>
+					</a>
+				</li>
+				<li>
+					Sign up for VTechWorks News at 
+					<a>
+						<xsl:attribute name="href">
+							<xsl:text>https://groups.google.com/a/vt.edu/forum/#!forum/vtechworks-g/join</xsl:text>
+						</xsl:attribute>
+						<xsl:text>https://groups.google.com/a/vt.edu/forum/#!forum/vtechworks-g/join</xsl:text>
+					</a>
+					 to get monthly reports of planned features and new content. 
+				</li>
+			</ul>
+		</p>
+	</xsl:template>
+</xsl:stylesheet>

--- a/dspace/modules/xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
@@ -43,9 +43,11 @@
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.date.issued">Date Issued</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dateIssued">Date Issued</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_type">Content Type</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">ETD Advisor</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_etdlevel">ETD Level</message>
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Committee Chair</message>
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_committeemember">Committee Member</message>
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_etdlevel">Thesis Degree Level</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Department</message>
+    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.relation.ispartofseries_filter">Series</message>
 
     <!-- Site Leve Recently Added Content -->
     <message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">Recently Added</message>
@@ -64,14 +66,10 @@
     <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by">Group Results By</message>
     <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.none">None</message>
 
-
     <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.publication_grp">Publication</message>
 
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.comm">Community</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.coll">Collection</message>
-
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.relation.ispartofseries_filter">Series</message>
 
     <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.contributor.author_browse">Browsing by: Author</message>
     <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.title_browse">Browsing by: Title</message>
@@ -90,7 +88,7 @@
     <message key="xmlui.ArtifactBrowser.AbstractSearch.type_relation_browse">Browsing by: Relation</message>
     <message key="xmlui.ArtifactBrowser.AbstractSearch.type_mime_browse">Browsing by: Mime-Type</message>
     <message key="xmlui.ArtifactBrowser.AbstractSearch.type_other_browse">Browsing by: Other Contributor</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_advisor_browse">Browsing by: Advisor</message>
+    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_advisor_browse">Browsing by: Committee Chair</message>
     <message key="xmlui.ArtifactBrowser.AbstractSearch.type_department_browse">Browsing by: Department</message>
     <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dateissued_dt_browse">Browsing by: Issue date</message>
 
@@ -105,6 +103,7 @@
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.language">Language (ISO)</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.coverage">Coverage</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.trnumber">Technical Report No.</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.committeemember">Committee Member</message>
 
     <message key="xmlui.dri2xhtml.structural.pagination-info.nototal">Now showing items {0}-{1}</message>
 
@@ -117,15 +116,15 @@
     <message key="xmlui.Discovery.AbstractSearch.type_type">Filter by: Content Type</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.type">Content Type</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.type_type">Content Type</message>
-    <message key="xmlui.Discovery.AbstractSearch.type_advisor">Filter by: ETD Advisor</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.advisor">ETD Advisor</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.advisor_filter">ETD Advisor</message>
+    <message key="xmlui.Discovery.AbstractSearch.type_advisor">Filter by: Committee Chair</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.advisor">Committee Chair</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.advisor_filter">Committee Chair</message>
     <message key="xmlui.Discovery.AbstractSearch.type_department">Filter by: Department</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.department">Department</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.department_filter">Department</message>
-    <message key="xmlui.Discovery.AbstractSearch.type_etdlevel">Filter by: ETD Level</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.etdlevel">ETD Level</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.etdlevel_filter">ETD Level</message>
+    <message key="xmlui.Discovery.AbstractSearch.type_etdlevel">Filter by: Thesis Degree Level</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.etdlevel">Thesis Degree Level</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.etdlevel_filter">Thesis Degree Level</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued.year">Date Issued</message>
 
 

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -131,7 +131,8 @@
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Keyword</message>
 
    <!--  some common other possibilities for Advanced Search Fields -->
-   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Contributor</message>
+<!-- repeats of definitions in Discovery/i18n/messages.xml
+<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Contributor</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Creator</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Description</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Relation</message>
@@ -139,6 +140,7 @@
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Other Contributor</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Advisor</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Department</message>
+-->
 
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Full Text</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">AND</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -61,6 +61,8 @@
     <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Only authenticated users who are administrators may assume the login as another user.</message>
     <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">You may not assume the login as another administrator.</message>
 
+	<!-- Jing Pu added -->
+	<message key="xmlui.static.header">VTechWorks</message>
 
 	<!--
 		This section is for feed syndications (RSS, atom, etc)
@@ -2492,12 +2494,63 @@
     <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
     <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
 
-    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+ 	<!-- Added static pages tag title -->
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About</message>
+    <message key="xmlui.mirage2.page-structure.policiesThisRepository">Policies</message>
+    <message key="xmlui.mirage2.page-structure.helpThisRepository">Help</message>
+    
     <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
 
+	<!-- Jing Pu modified -->
+	<!--  
+	<message key="xmlui.mirage2.page-structure.heroUnit.about.title8">8 About VTechWork Title </message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.about.content8">8 About To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+	<message key="xmlui.mirage2.page-structure.heroUnit.about.title9">9 About VTechWork Title </message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.about.content9">9 About To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+	<message key="xmlui.mirage2.page-structure.heroUnit.about.title10">10 About VTechWork Title </message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.about.content10">10 About To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+	-->
+	<message key="xmlui.mirage2.page-structure.heroUnit.about.title11">11 About VTechWork Title </message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.about.content11">11 About To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+	<!-- 
+	<message key="xmlui.mirage2.page-structure.heroUnit.about.title12">12 About VTechWork Title </message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.about.content12">12 About To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+	-->
+	
+	<!--
+	<message key="xmlui.mirage2.page-structure.heroUnit.pol.title8">8 Policies VTechWork Title </message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.pol.content8">8 Policies To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+	<message key="xmlui.mirage2.page-structure.heroUnit.pol.title9">9 Policies VTechWork Title </message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.pol.content9">9 Policies To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+	<message key="xmlui.mirage2.page-structure.heroUnit.pol.title10">10 Policies VTechWork Title </message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.pol.content10">10 Policies To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+	-->
+	<message key="xmlui.mirage2.page-structure.heroUnit.pol.title11">11 Policies VTechWork Title </message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.pol.content11">11 Policies To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+	<!-- 
+	<message key="xmlui.mirage2.page-structure.heroUnit.pol.title12">12 Policies VTechWork Title </message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.pol.content12">12 Policies To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+	-->
+	
+	<!--
+	<message key="xmlui.mirage2.page-structure.heroUnit.help.title8">8 Help VTechWork Title </message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.help.content8">8 Help To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+	<message key="xmlui.mirage2.page-structure.heroUnit.help.title9">9 Help VTechWork Title </message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.help.content9">9 Help To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+	<message key="xmlui.mirage2.page-structure.heroUnit.help.title10">10 Help VTechWork Title </message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.help.content10">10 Help To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+	-->
+	<message key="xmlui.mirage2.page-structure.heroUnit.help.title11">11 Help VTechWork Title </message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.help.content11">11 Help To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+	<!-- 
+	<message key="xmlui.mirage2.page-structure.heroUnit.help.title12">12 Help VTechWork Title </message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.help.content12">12 Help To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+	-->
+	
+	<!--
     <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
     <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
-
+	-->
     <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
 
     <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>


### PR DESCRIPTION
Made additional modifications to search filters and facets after consultation with others.  
Change search facets and filters for ETD and other collections
    Add committee member filter; remove sponsor filter from ETD list; remove mime-type and coverage
    filters from filter lists for all collections; rename ETD Advisor Committee Chair; rename
    ETD level Thesis degree level; comment out duplicate labels in overlay messages.xml.