### PR TITLE
#51

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/XSLUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/utils/XSLUtils.java
@@ -68,6 +68,11 @@ public class XSLUtils {
      * maxDeviation chars from the targetLength, or at the targetLength if no such space is found
      */
     public static String htmlToShortString(String htmlString, int targetLength, int maxDeviation) {
-    	return shortenString(htmlToText(htmlString), targetLength, maxDeviation);
+    	if (-1 == targetLength && -1 == maxDeviation) {
+    		return htmlToText(htmlString);
+    	}
+    	else {
+    		return shortenString(htmlToText(htmlString), targetLength, maxDeviation);
+    	}
     }
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -529,9 +529,15 @@
                         <xsl:value-of select="./@qualifier"/>
                     </xsl:if>
                 </td>
-            <td class="word-break">
-              <xsl:copy-of select="./node()"/>
-            </td>
+                <!-- Item full view remove html tags from fields, e.g., abstract -->
+	            <td class="word-break">
+	              <!--  
+	              <xsl:copy-of select="./node()"/>
+	              
+	              <xsl:value-of select="./node()" disable-output-escaping="yes" />
+	              -->
+	              <xsl:value-of select="util:htmlToShortString(./node(), -1, -1)"/>
+	            </td>
                 <td><xsl:value-of select="./@language"/></td>
             </tr>
     </xsl:template>


### PR DESCRIPTION
Enable HTML in Full Item View. Now the html tags are removed from
abstract field in item full view, and abstract field shows as plain
text.