### PR TITLE
Fix bug #51:Enable HTML in Full Item View

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -529,9 +529,15 @@
                         <xsl:value-of select="./@qualifier"/>
                     </xsl:if>
                 </td>
-            <td class="word-break">
-              <xsl:copy-of select="./node()"/>
-            </td>
+                <!-- Item full view remove html tags from fields, e.g., abstract -->
+	            <td class="word-break">
+	              <!--  
+	              <xsl:copy-of select="./node()"/>
+	              
+	              <xsl:value-of select="./node()" disable-output-escaping="yes" />
+	              -->
+	              <xsl:value-of select="util:htmlToShortString(./node(), -1, -1)"/>
+	            </td>
                 <td><xsl:value-of select="./@language"/></td>
             </tr>
     </xsl:template>

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/utils/XSLUtils.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/utils/XSLUtils.java
@@ -1,0 +1,79 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.utils;
+
+import org.jsoup.Jsoup;
+
+/**
+ * Utilities that are needed in XSL transformations.
+ *
+ * @author Art Lowel (art dot lowel at atmire dot com)
+ */
+public class XSLUtils {
+
+    /*
+     * Cuts off the string at the space nearest to the targetLength if there is one within
+     * maxDeviation chars from the targetLength, or at the targetLength if no such space is
+     * found
+     */
+    public static String shortenString(String string, int targetLength, int maxDeviation) {
+        targetLength = Math.abs(targetLength);
+        maxDeviation = Math.abs(maxDeviation);
+        if (string == null || string.length() <= targetLength + maxDeviation)
+        {
+            return string;
+        }
+
+
+        int currentDeviation = 0;
+        while (currentDeviation <= maxDeviation) {
+            try {
+                if (string.charAt(targetLength) == ' ')
+                {
+                    return string.substring(0, targetLength) + " ...";
+                }
+                if (string.charAt(targetLength + currentDeviation) == ' ')
+                {
+                    return string.substring(0, targetLength + currentDeviation) + " ...";
+                }
+                if (string.charAt(targetLength - currentDeviation) == ' ')
+                {
+                    return string.substring(0, targetLength - currentDeviation) + " ...";
+                }
+            } catch (Exception e) {
+                //just in case
+            }
+
+            currentDeviation++;
+        }
+
+        return string.substring(0, targetLength) + " ...";
+
+    }
+    
+    /*
+     * Remove html tags from String
+     */
+    public static String htmlToText(String htmlString) {
+    	return Jsoup.parse(htmlString).text();
+    }
+    
+    /*
+     * Remove html tags from String, and Cuts off the string at the space nearest to the targetLength if there is one within
+     * maxDeviation chars from the targetLength, or at the targetLength if no such space is found
+     */
+    public static String htmlToShortString(String htmlString, int targetLength, int maxDeviation) {
+    	if (-1 == targetLength && -1 == maxDeviation) {
+            // handle the whole test and return
+    		return htmlToText(htmlString);
+    	}
+    	else {
+    		return shortenString(htmlToText(htmlString), targetLength, maxDeviation);
+    	}
+    }
+}


### PR DESCRIPTION
Enable HTML in Full Item View. Now the html tags are removed from
abstract field in item full view, and abstract field shows as plain
text. Customization overlay.