### PR TITLE
Remove "Select a community to browse its collections" from home page

### DIFF
--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/CommunityBrowser.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/CommunityBrowser.java
@@ -199,7 +199,8 @@ public class CommunityBrowser extends AbstractDSpaceTransformer implements Cache
     {
         Division division = body.addDivision("comunity-browser", "primary");
         division.setHead(T_head);
-        division.addPara(T_select);
+        // remove "Select a community to browse its collections" from home page
+        //division.addPara(T_select);
 
         TreeNode root = buildTree(Community.findAllTop(context));
         


### PR DESCRIPTION
Create “CommunityBrowser.java” in dspace/modules/xmlui/ as an overlay,
remove paragraph “T_select” from method “addBody” in this class.
Resolves: #19 Request to remove "Select a community to browse its
collections"