### PR TITLE
Fix #18 bug with abstract display of word breaks

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/_style.scss
@@ -34,3 +34,20 @@
 .navbar-toggle {
 padding: 2px;
 }
+
+// Removes word-break class so words don't break in the middle in abstracts 
+
+.ds-table-responsive {
+    @media (max-width: $screen-xs-max) {
+        overflow-x: auto;
+    }
+}
+
+.word-break {
+word-break:normal;
+-webkit-hyphens:none;
+-moz-hyphens:none;
+hyphens:none;
+}
+
+


### PR DESCRIPTION
This commit makes a change to the _style.scss file in the vtmirage2 theme to override the .word-break class. This is a good candidate for a change to the Mirage2 theme project, unless there is some local factor that made this display option appear wrongly for us.
