### PR TITLE
separate publishers in list view

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-list.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-list.xsl
@@ -154,7 +154,16 @@
 	                    <xsl:text>(</xsl:text>
 	                    <xsl:if test="dim:field[@element='publisher']">
 	                        <span class="publisher">
+	                        	<!-- Jing Pu modified -->
+	                        	<!--
 	                            <xsl:copy-of select="dim:field[@element='publisher']/node()"/>
+	                            -->
+								<xsl:for-each select="dim:field[@element='publisher']">
+									<xsl:copy-of select="node()"/>
+									<xsl:if test="count(following-sibling::dim:field[@element='publisher']) != 0">
+										<xsl:text>; </xsl:text>
+									</xsl:if>
+								</xsl:for-each>
 	                        </span>
 	                        <xsl:text>, </xsl:text>
 	                    </xsl:if>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-list.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-list.xsl
@@ -154,7 +154,7 @@
 	                    <xsl:text>(</xsl:text>
 	                    <xsl:if test="dim:field[@element='publisher']">
 	                        <span class="publisher">
-	                        	<!-- Jing Pu modified -->
+	                        	<!-- Separates multiple publishers -->
 	                        	<!--
 	                            <xsl:copy-of select="dim:field[@element='publisher']/node()"/>
 	                            -->


### PR DESCRIPTION
Changed item-list.xsl. Separates multiple publishers using “;”.

Resolved:  #68 Publisher information is concatenated in search results