### PR TITLE
Change the ordering of viewing by issue data to desc

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1146,7 +1146,7 @@ webui.strengths.show = true
 #
 # For compatibility with previous versions:
 #
-webui.browse.index.1 = dateissued:item:dateissued
+webui.browse.index.1 = dateissued:item:dateissued:desc
 webui.browse.index.2 = author:metadata:dc.contributor.*,dc.creator:text
 webui.browse.index.3 = title:item:title
 webui.browse.index.4 = subject:metadata:dc.subject.*:text


### PR DESCRIPTION
Changed "webui.browse.index.1 = dateissued:item:dateissued:desc" in dspace.cfg
Resolved: VTechWorks Backlog >> When viewing by issue date, make
default ordering "descending"
