### PR TITLE
Fix HTML in All metadata fields

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-list.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-list.xsl
@@ -94,8 +94,9 @@
                         <xsl:value-of select="$href"/>
                     </xsl:attribute>
                     <xsl:choose>
+                    	<!-- html encoding for 'title' filed -->
                         <xsl:when test="dim:field[@element='title']">
-                            <xsl:value-of select="dim:field[@element='title'][1]/node()"/>
+                            <xsl:value-of select="dim:field[@element='title'][1]/node()" disable-output-escaping="yes"/>
                         </xsl:when>
                         <xsl:otherwise>
                             <i18n:text>xmlui.dri2xhtml.METS-1.0.no-title</i18n:text>
@@ -177,11 +178,11 @@
             <xsl:if test="dim:field[@element = 'description' and @qualifier='abstract']">
                 <xsl:variable name="abstract" select="dim:field[@element = 'description' and @qualifier='abstract']/node()"/>
                 <div class="artifact-abstract">
-                	<!-- remove html tags from abstract field in the item list view -->
-                	<!--
-                    <xsl:value-of select="util:shortenString($abstract, 220, 10)"/>
-                    -->
+                	<!-- enable html tags for abstract field in the item list view -->
+                    <xsl:value-of select="util:shortenString($abstract, 220, 10)" disable-output-escaping="yes"/>
+                    <!--
                     <xsl:value-of select="util:htmlToShortString($abstract, 220, 10)"/>
+                    -->
                     
                 </div>
             </xsl:if>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -179,16 +179,17 @@
     </xsl:template>
 
     <xsl:template name="itemSummaryView-DIM-title">
+    	<!-- html encoding for 'title' filed -->
         <xsl:choose>
             <xsl:when test="count(dim:field[@element='title'][not(@qualifier)]) &gt; 1">
                 <h2 class="page-header first-page-header">
-                    <xsl:value-of select="dim:field[@element='title'][not(@qualifier)][1]/node()"/>
+                    <xsl:value-of select="dim:field[@element='title'][not(@qualifier)][1]/node()" disable-output-escaping="yes" />
                 </h2>
                 <div class="simple-item-view-other">
                     <p class="lead">
                         <xsl:for-each select="dim:field[@element='title'][not(@qualifier)]">
                             <xsl:if test="not(position() = 1)">
-                                <xsl:value-of select="./node()"/>
+                                <xsl:value-of select="./node()" disable-output-escaping="yes"/>
                                 <xsl:if test="count(following-sibling::dim:field[@element='title'][not(@qualifier)]) != 0">
                                     <xsl:text>; </xsl:text>
                                     <br/>
@@ -201,7 +202,7 @@
             </xsl:when>
             <xsl:when test="count(dim:field[@element='title'][not(@qualifier)]) = 1">
                 <h2 class="page-header first-page-header">
-                    <xsl:value-of select="dim:field[@element='title'][not(@qualifier)][1]/node()"/>
+                    <xsl:value-of select="dim:field[@element='title'][not(@qualifier)][1]/node()" disable-output-escaping="yes"/>
                 </h2>
             </xsl:when>
             <xsl:otherwise>
@@ -545,14 +546,15 @@
                         <xsl:value-of select="./@qualifier"/>
                     </xsl:if>
                 </td>
-                <!-- Item full view remove html tags from fields, e.g., abstract -->
+                <!-- Item full view enabling html for all fields, e.g., abstract -->
 	            <td class="word-break">
 	              <!--  
 	              <xsl:copy-of select="./node()"/>
-	              
-	              <xsl:value-of select="./node()" disable-output-escaping="yes" />
 	              -->
+	              <xsl:value-of select="./node()" disable-output-escaping="yes" />
+	              <!--  
 	              <xsl:value-of select="util:htmlToShortString(./node(), -1, -1)"/>
+	              -->
 	            </td>
                 <td><xsl:value-of select="./@language"/></td>
             </tr>


### PR DESCRIPTION
Show html-tag rendered metadata fields correctly, e.g., subject, title,
abstract. Modified item-list.xsl and item-view.xsl, add
“disable-output-escaping="yes” attribute.
Resolved: #84 Fix HTML in ALL the fields