### PR TITLE
Display of long item file name needs wrapping

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/_style.scss
@@ -51,4 +51,9 @@ hyphens:none;
 text-align:justify;
 }
 
+.filename-word-break {
+word-break:break-all;
+width:200px;
+}
+
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -447,7 +447,8 @@
         <xsl:param name="title" />
         <xsl:param name="label" />
         <xsl:param name="size" />
-        <div>
+        <!-- display of long file name -->
+		<div class="filename-word-break">
             <a>
                 <xsl:attribute name="href">
                     <xsl:value-of select="$href"/>


### PR DESCRIPTION
Changed _style.acss, and item-view.xl, add new css class “filename-word-break”

Resolved:  #138 Display of long item file name needs wrapping
