### PR TITLE
Enable display of line break in abstract fields in simple and full item view

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/_style.scss
@@ -51,4 +51,7 @@ hyphens:none;
 text-align:justify;
 }
 
+.line-break {
+white-space:pre-line;
+}
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -252,7 +252,8 @@
         <xsl:if test="dim:field[@element='description' and @qualifier='abstract']">
             <div class="simple-item-view-description item-page-field-wrapper table">
                 <h5 class="visible-xs"><i18n:text>xmlui.dri2xhtml.METS-1.0.item-abstract</i18n:text></h5>
-                <div>
+                <!-- Show line break in abstract field. -->
+                <div class="line-break">
                     <xsl:for-each select="dim:field[@element='description' and @qualifier='abstract']">
                         <xsl:choose>
                             <xsl:when test="node()">
@@ -547,7 +548,8 @@
                     </xsl:if>
                 </td>
                 <!-- Item full view enabling html for all fields, e.g., abstract -->
-	            <td class="word-break">
+                <!-- Render abstract by line break -->
+	            <td class="word-break line-break">
 	              <!--  
 	              <xsl:copy-of select="./node()"/>
 	              -->


### PR DESCRIPTION
Changed _style.scss, and item-view.xl. Added new css class “line-break”
Resolved:  #143 Enable display of line returns in metadata fields in
simple item view and full item view
