### PR TITLE
Add TR number in search and browsing results

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-list.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-list.xsl
@@ -179,6 +179,13 @@
 	                    <xsl:text>)</xsl:text>
                         </small></span>
                 </xsl:if>
+                <!-- Add tr number infomation -->
+				<xsl:if test="dim:field[@element='identifier' and @qualifier='trnumber']">
+					<span class="trnumber h4"><small>
+						<xsl:text>, </xsl:text>
+						<xsl:value-of select="dim:field[@element='identifier' and @qualifier='trnumber']/node()"/>
+					</small></span>	
+                </xsl:if>
             </div>
             <xsl:if test="dim:field[@element = 'description' and @qualifier='abstract']">
                 <xsl:variable name="abstract" select="dim:field[@element = 'description' and @qualifier='abstract']/node()"/>
@@ -342,6 +349,13 @@
                             <xsl:text>)</xsl:text>
                         </span>
                     </xsl:if>
+					<!-- Add tr number infomation -->
+					<xsl:if test="dim:field[@element='identifier' and @qualifier='trnumber']">
+						<span class="trnumber h4"><small>
+							<xsl:text>, </xsl:text>
+							<xsl:value-of select="dim:field[@element='identifier' and @qualifier='trnumber']/node()"/>
+						</small></span>	
+                	</xsl:if>
                 </div>
             </div>
         </xsl:template>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/discovery/discovery.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/discovery/discovery.xsl
@@ -273,6 +273,13 @@
                             <xsl:text>)</xsl:text>
                             </small></span>
                     </xsl:if>
+					<!-- Add tr number infomation -->
+					<xsl:if test="dri:list[@n=(concat($handle, ':dc.identifier.trnumber'))]">
+						<span class="trnumber h4"><small>
+							<xsl:text>, </xsl:text>
+							<xsl:value-of select="dri:list[@n=(concat($handle, ':dc.identifier.trnumber'))]/dri:item"/>
+						</small></span>	
+                	</xsl:if>
                     <xsl:choose>
                         <xsl:when test="dri:list[@n=(concat($handle, ':dc.description.abstract'))]/dri:item/dri:hi">
                             <div class="abstract">


### PR DESCRIPTION
Display TR number in the search and browsing results if available.
Changed item-list.xsl and discovery.xl.

Resolved: #152 Improve display of CS Technical Reports
