### PR TITLE
correct "dcterms.conformsTo" in registry

### DIFF
--- a/dspace/config/registries/dcterms-types.xml
+++ b/dspace/config/registries/dcterms-types.xml
@@ -93,7 +93,7 @@
 
   <dc-type>
 	<schema>dcterms</schema>
-    <element>comformsTo</element>
+    <element>conformsTo</element>
     <scope_note>An established standard to which the described resource conforms.</scope_note>
   </dc-type>
 


### PR DESCRIPTION
Changed dcterms-types.xml, correct metadata element
”dcterms.conformsTo" in dspace registry.

Resolved: #164 Incorrect metadata element in the "dcterms" registry
("dcterms.comformsTo")
