### PR TITLE
Make "get help" more promiment on home page

### DIFF
--- a/dspace/config/news-xmlui.xml
+++ b/dspace/config/news-xmlui.xml
@@ -3,7 +3,7 @@
 <body>
 <div id="file.news.div.news" n="news" rend="primary">
 <head>VTechWorks</head>
-<p>VTechWorks publicizes and preserves the scholarly work of Virginia Tech faculty, students, and staff: journal articles, books, theses, dissertations, conference papers, slide presentations, technical reports, working papers, administrative documents, videos, images, data sets, and more. <xref target="http://j.mp/vtechworks-service">Get help</xref> adding your content to VTechWorks or <xref target="https://groups.google.com/a/vt.edu/forum/#!forum/vtechworks-g/join">sign up for VTechWorks News</xref> to get monthly reports of planned features and new content.</p> 
+<p>VTechWorks publicizes and preserves the scholarly work of Virginia Tech faculty, students, and staff: journal articles, books, theses, dissertations, conference papers, slide presentations, technical reports, working papers, administrative documents, videos, images, data sets, and more. <xref target="http://j.mp/vtechworks-service" rend="a-bold">Get help</xref> adding your content to VTechWorks or <xref target="https://groups.google.com/a/vt.edu/forum/#!forum/vtechworks-g/join">sign up for VTechWorks News</xref> to get monthly reports of planned features and new content.</p> 
 </div>
 </body>
 <options/>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/_style.scss
@@ -60,3 +60,6 @@ word-break:break-all;
 width:200px;
 }
 
+.a-bold {
+font-weight: bold;
+}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/_style.scss
@@ -61,5 +61,5 @@ width:200px;
 }
 
 .a-bold {
-font-weight: bold;
+font-weight: 900;
 }


### PR DESCRIPTION
Changed news-xmli.xml and _style.scss, add font weight css style to “get help”.
Resolved:  Make "get help" more prominent on home page #175
