### PR TITLE
 Implement Altmetrics badges

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/core/elements.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/core/elements.xsl
@@ -72,6 +72,7 @@
             <xsl:call-template name="cc-license">
                 <xsl:with-param name="metadataURL" select="./dri:referenceSet/dri:reference/@url"/>
             </xsl:call-template>
+            <xsl:call-template name="altmetric" />
         </xsl:if>
         <xsl:apply-templates select="@pagination">
             <xsl:with-param name="position">bottom</xsl:with-param>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/core/page-structure.xsl
@@ -333,7 +333,9 @@
                 </script>
                 <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">&#160;</script>
             </xsl:if>
-
+            
+            <!-- Add Altmetric support -->
+			<script type='text/javascript' src='https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js'>&#160;</script>
         </head>
     </xsl:template>
 
@@ -712,6 +714,23 @@
                  <xsl:value-of select="$ccLicenseName"/>
              </xsl:attribute>
         </img>
+    </xsl:template>
+    
+	<!-- Altmetric -->
+	<xsl:template name="altmetric">
+		<xsl:variable name="citationAbsHtmlUrl"
+						select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='citation_abstract_html_url']"
+		/>
+
+        <xsl:if test="$citationAbsHtmlUrl">
+            <div class="row">
+            	<div class="col-sm-3 col-xs-12">
+                	<div class="altmetric-embed" data-badge-type="2" data-badge-details="right">
+                		<xsl:attribute name="data-handle"><xsl:value-of select="substring-after($citationAbsHtmlUrl, 'handle/')"/></xsl:attribute>
+                	</div>
+               </div>
+            </div>
+        </xsl:if>
     </xsl:template>
 
     <!-- Like the header, the footer contains various miscellaneous text, links, and image placeholders -->

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/core/page-structure.xsl
@@ -725,7 +725,7 @@
         <xsl:if test="$citationAbsHtmlUrl">
             <div class="row">
             	<div class="col-sm-3 col-xs-12">
-                	<div class="altmetric-embed" data-badge-type="2" data-badge-details="right">
+                	<div class="altmetric-embed" data-badge-type="medium-donut" data-badge-details="right">
                 		<xsl:attribute name="data-handle"><xsl:value-of select="substring-after($citationAbsHtmlUrl, 'handle/')"/></xsl:attribute>
                 	</div>
                </div>


### PR DESCRIPTION
Add Altmetrics support, use “data-handle” which comes from meta
“'citation_abstract_html_url'”. Changed page-structure.xl and
elements.xsl.

Resolved:  #181 Implement Altmetrics badges
