### PR TITLE
Make asterisk red in required fields in submission form

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_forms.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_forms.scss
@@ -27,7 +27,7 @@
 
 .control-label.required::after {
     content: "*";
-    color: red;
+    color: $burnt-orange;
 }
 
 .submission .ds-add-button {

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_forms.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_forms.scss
@@ -1,0 +1,35 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+//.ds-form-item.row {
+//    margin-bottom: 15px;
+//}
+
+.submission .ds-form-item {
+    margin-bottom: 30px;
+}
+
+.submission .panel .ds-form-item {
+    margin-bottom: 5px;
+}
+
+.submission .panel .ds-form-item:last-child {
+    margin-bottom: 0px;
+}
+
+.needs-xs-spacing {
+    margin-bottom: 5px;
+}
+
+.control-label.required::after {
+    content: "*";
+    color: red;
+}
+
+.submission .ds-add-button {
+    min-width: 100%;
+}


### PR DESCRIPTION
Changed css style of “.control-label.required::after”in forms.css, add
color “red” to “*”
Resolved:  #187 In the submission form, make the asterisk for a
required field red
