### PR TITLE
Create a new default traditional submission form

### DIFF
--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -44,15 +44,32 @@
 			<page number="1">
 				<field>
 					<dc-schema>dc</dc-schema>
+					<dc-element>type</dc-element>
+					<dc-qualifier></dc-qualifier>
+					<repeatable>true</repeatable>
+					<label>Item Type</label>
+					<input-type value-pairs-name="common_types">dropdown</input-type>
+					<hint>Select the type(s) of content you are depositing. To select more than 
+					one value in the list, you may have to hold down the "CTRL" or "Shift" or "COMMAND" key. 
+					Examples: Article, Learning Object, Video Recording and Presentation. </hint>
+					<required></required>
+				</field>
+			
+				<field>
+					<dc-schema>dc</dc-schema>
 					<dc-element>contributor</dc-element>
 					<dc-qualifier>author</dc-qualifier>
 					<repeatable>true</repeatable>
-					<label>Authors</label>
+					<label>Author(s)/Creator(s)</label>
 					<input-type>name</input-type>
-					<hint>Enter the names of the authors of this item.</hint>
+					<hint>Enter the name(s) of the author(s) or creator(s). Enter each name individually, 
+					then click "Add".
+					To use VTechWorks' name lookup function, click "Lookup" and you will be directed to an 
+					index of VTechWorks' creator and contributor names. Examples: Faulkner, William; Einstein, 
+					Albert; Lovelace, Ada.</hint>
 					<required></required>
 				</field>
-
+				
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>title</dc-element>
@@ -60,36 +77,35 @@
 					<repeatable>false</repeatable>
 					<label>Title</label>
 					<input-type>onebox</input-type>
-					<hint>Enter the main title of the item.</hint>
+					<hint>Enter the title or name of the item. If a title is not provided, create one that appropriately 
+					describes the item. Examples: Extended Boolean Information Retrieval, Ossian and the Genres of Culture, 
+					Chemistry of Arsenic Removal During Coagulation and Fe-Mn Oxidation.</hint>
 					<required>You must enter a main title for this item.</required>
 				</field>
-
+				
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>title</dc-element>
-					<dc-qualifier>alternative</dc-qualifier>
-					<repeatable>true</repeatable>
-					<label>Other Titles</label>
+					<dc-qualifier>serial</dc-qualifier>
+					<repeatable>false</repeatable>
+					<label>Journal Title</label>
 					<input-type>onebox</input-type>
-					<hint>If the item has any alternative titles, please enter them
-						here.</hint>
+					<hint>Foreign Affairs, PLOS One, Nature.</hint>
 					<required></required>
 				</field>
-
+				
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>date</dc-element>
 					<dc-qualifier>issued</dc-qualifier>
 					<repeatable>false</repeatable>
-					<label>Date of Issue</label>
+					<label>Date</label>
 					<input-type>date</input-type>
-					<hint>Please give the date of previous publication or public
-						distribution.
-						You can leave out the day and/or month if they aren't
-						applicable.</hint>
+					<hint>Enter date of publication or public distribution. A year is required, but month and day are optional. 
+					If the item has not been previously published, enter today's date. Examples: 2010, 1969 July 01, 1995 August.</hint>
 					<required>You must enter at least the year.</required>
 				</field>
-
+				
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>publisher</dc-element>
@@ -97,35 +113,23 @@
 					<repeatable>false</repeatable>
 					<label>Publisher</label>
 					<input-type>onebox</input-type>
-					<hint>Enter the name of the publisher of the previously issued
-						instance of this item.</hint>
+					<hint>If the item has been published or accepted for publication, enter the publisher. If the item has not 
+					been published, enter "Virginia Tech." Examples: Wiley, Cornell University Press, Taylor &amp; Francis.</hint>
 					<required></required>
 				</field>
-
-				<field>
-					<dc-schema>dc</dc-schema>
-					<dc-element>identifier</dc-element>
-					<dc-qualifier>citation</dc-qualifier>
-					<repeatable>false</repeatable>
-					<label>Citation</label>
-					<input-type>onebox</input-type>
-					<hint>Enter the standard citation for the previously issued
-						instance of this item.</hint>
-					<required></required>
-				</field>
-
+				
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>relation</dc-element>
 					<dc-qualifier>ispartofseries</dc-qualifier>
 					<repeatable>true</repeatable>
-					<label>Series/Report No.</label>
+					<label>Series/Report Number</label>
 					<input-type>series</input-type>
-					<hint>Enter the series and number assigned to this item by your
-						community.</hint>
+					<hint>Enter the series and number assigned to this item. Examples: Virginia Cooperative Extension BSE-51NP, 
+					Airport Cooperative Research Program 124, TMC75-07-H-00008.</hint>
 					<required></required>
 				</field>
-
+				
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>identifier</dc-element>
@@ -134,25 +138,11 @@
 					<repeatable>true</repeatable>
 					<label>Identifiers</label>
 					<input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
-					<hint>If the item has any identification numbers or codes
-						associated with
-						it, please enter the types and the actual numbers or codes.</hint>
+					<hint>If the item has any identification numbers or codes associated with it, please enter them. Examples: 
+					ISSN 0272-3638, DOI 10.1056/NEJMoa1510991, URL http://www.johncairns.net/ebook2.htm.</hint>
 					<required></required>
 				</field>
-
-				<field>
-					<dc-schema>dc</dc-schema>
-					<dc-element>type</dc-element>
-					<dc-qualifier></dc-qualifier>
-					<repeatable>true</repeatable>
-					<label>Type</label>
-					<input-type value-pairs-name="common_types">dropdown</input-type>
-					<hint>Select the type(s) of content of the item. To select more
-						than one value in the list, you may have to hold down the "CTRL"
-						or "Shift" key.</hint>
-					<required></required>
-				</field>
-
+				
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>language</dc-element>
@@ -160,15 +150,12 @@
 					<repeatable>false</repeatable>
 					<label>Language</label>
 					<input-type value-pairs-name="common_iso_languages">dropdown</input-type>
-					<hint>Select the language of the main content of the item. If the
-						language does not appear in the list, please select 'Other'. If
-						the content does not really have a language (for example, if it is
-						a dataset or an image) please select 'N/A'.</hint>
+					<hint>Select the language of the main content of the item. If the language does not appear in the list, 
+					please select 'Other'. If the content does not really have a language (for example, if it is a dataset 
+					or an image) please select "N/A." Examples: English, French, Chinese.</hint>
 					<required></required>
 				</field>
-			</page>
-
-			<page number="2">
+				
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>subject</dc-element>
@@ -177,11 +164,12 @@
 					<repeatable>true</repeatable>
 					<label>Subject Keywords</label>
 					<input-type>twobox</input-type>
-					<hint>Enter appropriate subject keywords or phrases. </hint>
+					<hint>Enter any keywords or phrases that describe the item's content. Enter each keyword or phrase separately, 
+					then click "Add." Repeat for all keywords or phrases. Examples: New River Valley, VA [Add], remote sensing [Add], 
+					photogrammetry [Add].</hint>
 					<required></required>
-					<vocabulary>srsc</vocabulary>
 				</field>
-
+				
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>description</dc-element>
@@ -189,30 +177,31 @@
 					<repeatable>false</repeatable>
 					<label>Abstract</label>
 					<input-type>textarea</input-type>
-					<hint>Enter the abstract of the item. </hint>
+					<hint>Enter a brief summary of the item. Preferred length is a single paragraph or about 300 words, 
+					although you may enter an abstract of any length.</hint>
 					<required></required>
 				</field>
-
+				
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>description</dc-element>
 					<dc-qualifier>sponsorship</dc-qualifier>
-					<repeatable>false</repeatable>
-					<label>Sponsors</label>
-					<input-type>textarea</input-type>
-					<hint>Enter the names of any sponsors and/or funding codes in the
-						box. </hint>
+					<repeatable>true</repeatable>
+					<label>Funding</label>
+					<input-type>onebox</input-type>
+					<hint>Enter the names of any funders and/or grant numbers. Enter each funder name or grant number separately, 
+					then click "Add." Examples: National Science Foundation [Add], NSF: DMR-01-02277 [Add].</hint>
 					<required></required>
 				</field>
-
+				
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>description</dc-element>
-					<dc-qualifier></dc-qualifier>
+					<dc-qualifier>notes</dc-qualifier>
 					<repeatable>false</repeatable>
-					<label>Description</label>
+					<label>Notes</label>
 					<input-type>textarea</input-type>
-					<hint>Enter any other description or comments in this box. </hint>
+					<hint>Enter any additional information that will help describe the item.</hint>
 					<required></required>
 				</field>
 			</page>
@@ -334,7 +323,7 @@
 					<input-type value-pairs-name="common_types">dropdown</input-type>
 					<hint>Select the type(s) of content of the item. To select more
 						than one value in the list, you may have to hold down the "CTRL"
-						or "Shift" key.</hint>
+						or "Shift" or "COMMAND" key.</hint>
 					<required></required>
 				</field>
 				
@@ -726,35 +715,39 @@
 		<value-pairs value-pairs-name="common_identifiers"
 			dc-term="identifier">
 			<pair>
-				<displayed-value>ISSN</displayed-value>
-				<stored-value>issn</stored-value>
-			</pair>
-			<pair>
-				<displayed-value>Other</displayed-value>
-				<stored-value>other</stored-value>
-			</pair>
-			<pair>
-				<displayed-value>ISMN</displayed-value>
-				<stored-value>ismn</stored-value>
+				<displayed-value>DOI (Digital Object Identifier)</displayed-value>
+				<stored-value>doi</stored-value>
 			</pair>
 			<pair>
 				<displayed-value>Gov't Doc #</displayed-value>
 				<stored-value>govdoc</stored-value>
 			</pair>
 			<pair>
-				<displayed-value>URI</displayed-value>
-				<stored-value>uri</stored-value>
-			</pair>
-			<pair>
 				<displayed-value>ISBN</displayed-value>
 				<stored-value>isbn</stored-value>
+			</pair>
+			<pair>
+				<displayed-value>ISMN</displayed-value>
+				<stored-value>ismn</stored-value>
+			</pair>
+			<pair>
+				<displayed-value>ISSN</displayed-value>
+				<stored-value>issn</stored-value>
+			</pair>
+			<pair>
+				<displayed-value>URL (web link)</displayed-value>
+				<stored-value>url</stored-value>
+			</pair>
+			<pair>
+				<displayed-value>Other</displayed-value>
+				<stored-value>other</stored-value>
 			</pair>
 		</value-pairs>
 
 		<value-pairs value-pairs-name="common_types" dc-term="type">
 			<pair>
-				<displayed-value>Animation</displayed-value>
-				<stored-value>Animation</stored-value>
+				<displayed-value>Audio recording</displayed-value>
+				<stored-value>Audio recording</stored-value>
 			</pair>
 			<pair>
 				<displayed-value>Article</displayed-value>
@@ -773,68 +766,40 @@
 				<stored-value>Dataset</stored-value>
 			</pair>
 			<pair>
-				<displayed-value>Learning Object</displayed-value>
-				<stored-value>Learning Object</stored-value>
+				<displayed-value>Dissertation</displayed-value>
+				<stored-value>Dissertation</stored-value>
 			</pair>
 			<pair>
 				<displayed-value>Image</displayed-value>
 				<stored-value>Image</stored-value>
 			</pair>
 			<pair>
-				<displayed-value>Image, 3-D</displayed-value>
-				<stored-value>Image, 3-D</stored-value>
+				<displayed-value>Learning Object</displayed-value>
+				<stored-value>Learning Object</stored-value>
 			</pair>
 			<pair>
 				<displayed-value>Map</displayed-value>
 				<stored-value>Map</stored-value>
 			</pair>
 			<pair>
-				<displayed-value>Musical Score</displayed-value>
-				<stored-value>Musical Score</stored-value>
-			</pair>
-			<pair>
-				<displayed-value>Plan or blueprint</displayed-value>
-				<stored-value>Plan or blueprint</stored-value>
-			</pair>
-			<pair>
-				<displayed-value>Preprint</displayed-value>
-				<stored-value>Preprint</stored-value>
-			</pair>
-			<pair>
 				<displayed-value>Presentation</displayed-value>
 				<stored-value>Presentation</stored-value>
-			</pair>
-			<pair>
-				<displayed-value>Recording, acoustical</displayed-value>
-				<stored-value>Recording, acoustical</stored-value>
-			</pair>
-			<pair>
-				<displayed-value>Recording, musical</displayed-value>
-				<stored-value>Recording, musical</stored-value>
-			</pair>
-			<pair>
-				<displayed-value>Recording, oral</displayed-value>
-				<stored-value>Recording, oral</stored-value>
 			</pair>
 			<pair>
 				<displayed-value>Software</displayed-value>
 				<stored-value>Software</stored-value>
 			</pair>
 			<pair>
-				<displayed-value>Technical Report</displayed-value>
-				<stored-value>Technical Report</stored-value>
+				<displayed-value>Report</displayed-value>
+				<stored-value>Report</stored-value>
 			</pair>
 			<pair>
 				<displayed-value>Thesis</displayed-value>
 				<stored-value>Thesis</stored-value>
 			</pair>
 			<pair>
-				<displayed-value>Video</displayed-value>
-				<stored-value>Video</stored-value>
-			</pair>
-			<pair>
-				<displayed-value>Working Paper</displayed-value>
-				<stored-value>Working Paper</stored-value>
+				<displayed-value>Video recording</displayed-value>
+				<stored-value>Video recording</stored-value>
 			</pair>
 			<pair>
 				<displayed-value>Other</displayed-value>
@@ -856,19 +821,19 @@
 			</pair>
 			<pair>
 				<displayed-value>English</displayed-value>
-				<stored-value>en</stored-value>
+				<stored-value>en_US</stored-value>
 			</pair>
 			<pair>
-				<displayed-value>Spanish</displayed-value>
-				<stored-value>es</stored-value>
-			</pair>
-			<pair>
-				<displayed-value>German</displayed-value>
-				<stored-value>de</stored-value>
+				<displayed-value>Chinese</displayed-value>
+				<stored-value>zh</stored-value>
 			</pair>
 			<pair>
 				<displayed-value>French</displayed-value>
 				<stored-value>fr</stored-value>
+			</pair>
+			<pair>
+				<displayed-value>German</displayed-value>
+				<stored-value>de</stored-value>
 			</pair>
 			<pair>
 				<displayed-value>Italian</displayed-value>
@@ -879,8 +844,8 @@
 				<stored-value>ja</stored-value>
 			</pair>
 			<pair>
-				<displayed-value>Chinese</displayed-value>
-				<stored-value>zh</stored-value>
+				<displayed-value>Spanish</displayed-value>
+				<stored-value>es</stored-value>
 			</pair>
 			<pair>
 				<displayed-value>Turkish</displayed-value>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -49,9 +49,7 @@
 					<repeatable>true</repeatable>
 					<label>Item Type</label>
 					<input-type value-pairs-name="common_types">dropdown</input-type>
-					<hint>Select the type(s) of content you are depositing. To select more than 
-					one value in the list, you may have to hold down the "CTRL" or "Shift" or "COMMAND" key. 
-					Examples: Article, Learning Object, Video Recording and Presentation. </hint>
+					<hint>Select the type(s) of content you are depositing. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" or "COMMAND" key. Examples: Article, Learning Object, Video Recording and Presentation. </hint>
 					<required></required>
 				</field>
 			
@@ -62,11 +60,7 @@
 					<repeatable>true</repeatable>
 					<label>Author(s)/Creator(s)</label>
 					<input-type>name</input-type>
-					<hint>Enter the name(s) of the author(s) or creator(s). Enter each name individually, 
-					then click "Add".
-					To use VTechWorks' name lookup function, click "Lookup" and you will be directed to an 
-					index of VTechWorks' creator and contributor names. Examples: Faulkner, William; Einstein, 
-					Albert; Lovelace, Ada.</hint>
+					<hint>Enter the name(s) of the author(s) or creator(s). Enter each name individually, then click "Add". To use VTechWorks' name lookup function, click "Lookup" and you will be directed to an index of VTechWorks' creator and contributor names. Examples: Faulkner, William; Einstein, Albert; Lovelace, Ada</hint>
 					<required></required>
 				</field>
 				
@@ -77,9 +71,7 @@
 					<repeatable>false</repeatable>
 					<label>Title</label>
 					<input-type>onebox</input-type>
-					<hint>Enter the title or name of the item. If a title is not provided, create one that appropriately 
-					describes the item. Examples: Extended Boolean Information Retrieval, Ossian and the Genres of Culture, 
-					Chemistry of Arsenic Removal During Coagulation and Fe-Mn Oxidation.</hint>
+					<hint>Enter the title or name of the item. If a title is not provided, create one that appropriately describes the item. Examples: Extended Boolean Information Retrieval, Ossian and the Genres of Culture, Chemistry of Arsenic Removal During Coagulation and Fe-Mn Oxidation</hint>
 					<required>You must enter a main title for this item.</required>
 				</field>
 				
@@ -90,7 +82,7 @@
 					<repeatable>false</repeatable>
 					<label>Journal Title</label>
 					<input-type>onebox</input-type>
-					<hint>Foreign Affairs, PLOS One, Nature.</hint>
+					<hint>Examples: Foreign Affairs, PLOS One, Nature</hint>
 					<required></required>
 				</field>
 				
@@ -101,8 +93,7 @@
 					<repeatable>false</repeatable>
 					<label>Date</label>
 					<input-type>date</input-type>
-					<hint>Enter date of publication or public distribution. A year is required, but month and day are optional. 
-					If the item has not been previously published, enter today's date. Examples: 2010, 1969 July 01, 1995 August.</hint>
+					<hint>Enter date of publication or public distribution. A year is required, but month and day are optional. If the item has not been previously published, enter today's date. Examples: 2010, 1969 July 01, 1995 August</hint>
 					<required>You must enter at least the year.</required>
 				</field>
 				
@@ -113,8 +104,7 @@
 					<repeatable>false</repeatable>
 					<label>Publisher</label>
 					<input-type>onebox</input-type>
-					<hint>If the item has been published or accepted for publication, enter the publisher. If the item has not 
-					been published, enter "Virginia Tech." Examples: Wiley, Cornell University Press, Taylor &amp; Francis.</hint>
+					<hint>If the item has been published or accepted for publication, enter the publisher. If the item has not been published, enter "Virginia Tech." Examples: Wiley, Cornell University Press, Taylor &amp; Francis</hint>
 					<required></required>
 				</field>
 				
@@ -125,8 +115,7 @@
 					<repeatable>true</repeatable>
 					<label>Series/Report Number</label>
 					<input-type>series</input-type>
-					<hint>Enter the series and number assigned to this item. Examples: Virginia Cooperative Extension BSE-51NP, 
-					Airport Cooperative Research Program 124, TMC75-07-H-00008.</hint>
+					<hint>Enter the series and number assigned to this item. Examples: Virginia Cooperative Extension BSE-51NP, Airport Cooperative Research Program 124, TMC75-07-H-00008</hint>
 					<required></required>
 				</field>
 				
@@ -138,8 +127,7 @@
 					<repeatable>true</repeatable>
 					<label>Identifiers</label>
 					<input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
-					<hint>If the item has any identification numbers or codes associated with it, please enter them. Examples: 
-					ISSN 0272-3638, DOI 10.1056/NEJMoa1510991, URL http://www.johncairns.net/ebook2.htm.</hint>
+					<hint>If the item has any identification numbers or codes associated with it, please enter them. Examples: ISSN 0272-3638, DOI 10.1056/NEJMoa1510991, URL http://www.johncairns.net/ebook2.htm</hint>
 					<required></required>
 				</field>
 				
@@ -150,9 +138,7 @@
 					<repeatable>false</repeatable>
 					<label>Language</label>
 					<input-type value-pairs-name="common_iso_languages">dropdown</input-type>
-					<hint>Select the language of the main content of the item. If the language does not appear in the list, 
-					please select 'Other'. If the content does not really have a language (for example, if it is a dataset 
-					or an image) please select "N/A." Examples: English, French, Chinese.</hint>
+					<hint>Select the language of the main content of the item. If the language does not appear in the list, please select 'Other'. If the content does not really have a language (for example, if it is a dataset or an image) please select "N/A." Examples: English, French, Chinese</hint>
 					<required></required>
 				</field>
 				
@@ -164,9 +150,7 @@
 					<repeatable>true</repeatable>
 					<label>Subject Keywords</label>
 					<input-type>twobox</input-type>
-					<hint>Enter any keywords or phrases that describe the item's content. Enter each keyword or phrase separately, 
-					then click "Add." Repeat for all keywords or phrases. Examples: New River Valley, VA [Add], remote sensing [Add], 
-					photogrammetry [Add].</hint>
+					<hint>Enter any keywords or phrases that describe the item's content. Enter each keyword or phrase separately, then click "Add." Repeat for all keywords or phrases. Examples: New River Valley, VA [Add], remote sensing [Add], photogrammetry [Add]</hint>
 					<required></required>
 				</field>
 				
@@ -177,8 +161,7 @@
 					<repeatable>false</repeatable>
 					<label>Abstract</label>
 					<input-type>textarea</input-type>
-					<hint>Enter a brief summary of the item. Preferred length is a single paragraph or about 300 words, 
-					although you may enter an abstract of any length.</hint>
+					<hint>Enter a brief summary of the item. Preferred length is a single paragraph or about 300 words, although you may enter an abstract of any length.</hint>
 					<required></required>
 				</field>
 				
@@ -189,8 +172,7 @@
 					<repeatable>true</repeatable>
 					<label>Funding</label>
 					<input-type>onebox</input-type>
-					<hint>Enter the names of any funders and/or grant numbers. Enter each funder name or grant number separately, 
-					then click "Add." Examples: National Science Foundation [Add], NSF: DMR-01-02277 [Add].</hint>
+					<hint>Enter the names of any funders and/or grant numbers. Enter each funder name or grant number separately, then click "Add." Examples: National Science Foundation [Add], NSF: DMR-01-02277 [Add]</hint>
 					<required></required>
 				</field>
 				
@@ -821,7 +803,7 @@
 			</pair>
 			<pair>
 				<displayed-value>English</displayed-value>
-				<stored-value>en_US</stored-value>
+				<stored-value>en</stored-value>
 			</pair>
 			<pair>
 				<displayed-value>Chinese</displayed-value>


### PR DESCRIPTION
According to the requirements in "MovingImageCustomSubmissionForm.xsl”,
changed input-forms.xml.
1. Implements the description fields in 1 page in default tradition
submission form.
2. Changed Value-pairs: “common_identifiers”, “common_types”,  and
“common_iso_languages”, so Value-pairs of “Type” and “Language” also
changed in OMALS, value-pairs of “Language” also changed in NDLTD

Resolved:
#198 Create a new default "traditional" submission form
