### PR TITLE
Volume issue submission

### DIFF
--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -150,7 +150,7 @@
 					<repeatable>false</repeatable>
 					<label>Journal Title</label>
 					<input-type>onebox</input-type>
-					<hint>Examples: Foreign Affairs, PLOS One, Nature; </hint>
+					<hint>Examples: Foreign Affairs, PLOS One, Nature</hint>
 					<required></required>
 				</field>
 								

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -85,6 +85,28 @@
 					<hint>Examples: Foreign Affairs, PLOS One, Nature</hint>
 					<required></required>
 				</field>
+								
+				<field>
+					<dc-schema>dc</dc-schema>
+					<dc-element>identifier</dc-element>
+					<dc-qualifier>volume</dc-qualifier>
+					<repeatable>false</repeatable>
+					<label>Volume</label>
+					<input-type>onebox</input-type>
+					<hint>Examples: 29, XVI, 1999</hint>
+					<required></required>
+				</field>
+				
+				<field>
+					<dc-schema>dc</dc-schema>
+					<dc-element>identifier</dc-element>
+					<dc-qualifier>issue</dc-qualifier>
+					<repeatable>false</repeatable>
+					<label>Issue</label>
+					<input-type>onebox</input-type>
+					<hint>Examples: 4, 2, Summer</hint>
+					<required></required>
+				</field>			
 				
 				<field>
 					<dc-schema>dc</dc-schema>
@@ -93,7 +115,7 @@
 					<repeatable>false</repeatable>
 					<label>Date</label>
 					<input-type>date</input-type>
-					<hint>Enter date of publication or public distribution. A year is required, but month and day are optional. If the item has not been previously published, enter today's date. Examples: 2010, 1969 July 01, 1995 August</hint>
+					<hint>Enter date of previous publication or public distribution. A year is required, but month and day are optional. If the item has not been previously published, enter today's date. Examples: 2010, 1969 July 01, 1995 August</hint>
 					<required>You must enter at least the year.</required>
 				</field>
 				

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -77,12 +77,80 @@
 				
 				<field>
 					<dc-schema>dc</dc-schema>
+					<dc-element>date</dc-element>
+					<dc-qualifier>issued</dc-qualifier>
+					<repeatable>false</repeatable>
+					<label>Date</label>
+					<input-type>date</input-type>
+					<hint>Enter date of previous publication or public distribution. A year is required, but month and day are optional. If the item has not been previously published, enter today's date. Examples: 2010, 1969 July 01, 1995 August</hint>
+					<required>You must enter at least the year.</required>
+				</field>				
+				
+				<field>
+					<dc-schema>dc</dc-schema>
+					<dc-element>description</dc-element>
+					<dc-qualifier>abstract</dc-qualifier>
+					<repeatable>false</repeatable>
+					<label>Abstract</label>
+					<input-type>textarea</input-type>
+					<hint>Enter a brief summary of the item. Preferred length is a single paragraph or about 300 words, although you may enter an abstract of any length.</hint>
+					<required></required>
+				</field>
+
+				<field>
+					<dc-schema>dc</dc-schema>
+					<dc-element>subject</dc-element>
+					<dc-qualifier></dc-qualifier>
+					<!-- An input-type of twobox MUST be marked as repeatable -->
+					<repeatable>true</repeatable>
+					<label>Subject Keywords</label>
+					<input-type>twobox</input-type>
+					<hint>Enter any keywords or phrases that describe the item's content, especially any that do not appear in the Abstract. Enter each keyword or phrase separately, then click "Add." Repeat for all keywords or phrases. Examples: New River Valley, VA [Add], remote sensing [Add], photogrammetry [Add]</hint>
+					<required></required>
+				</field>
+
+				<field>
+					<dc-schema>dc</dc-schema>
+					<dc-element>identifier</dc-element>
+					<dc-qualifier></dc-qualifier>
+					<!-- An input-type of qualdrop_value MUST be marked as repeatable -->
+					<repeatable>true</repeatable>
+					<label>Identifiers</label>
+					<input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
+					<hint>If the item has any identification numbers or codes associated with it, please enter them. Examples: DOI 10.1056/NEJMoa1510991, URL http://www.johncairns.net/ebook2.htm, ISSN 0272-3638</hint>
+					<required></required>
+				</field>
+
+				<field>
+					<dc-schema>dc</dc-schema>
+					<dc-element>language</dc-element>
+					<dc-qualifier>iso</dc-qualifier>
+					<repeatable>false</repeatable>
+					<label>Language</label>
+					<input-type value-pairs-name="common_iso_languages">dropdown</input-type>
+					<hint>Select the language of the main content of the item. If the language does not appear in the list, please select 'Other'. If the content does not really have a language (for example, if it is a dataset or an image) please select "N/A." Examples: English, French, Chinese</hint>
+					<required></required>
+				</field>
+				
+				<field>
+					<dc-schema>dc</dc-schema>
+					<dc-element>description</dc-element>
+					<dc-qualifier>notes</dc-qualifier>
+					<repeatable>false</repeatable>
+					<label>Conference Title</label>
+					<input-type>onebox</input-type>
+					<hint>Examples: Modern Language Association Annual Meeting, 2016 IEEE International Symposium on Circuits and Systems, Veterans in Society 2015.</hint>
+					<required></required>
+				</field>
+			
+				<field>
+					<dc-schema>dc</dc-schema>
 					<dc-element>title</dc-element>
 					<dc-qualifier>serial</dc-qualifier>
 					<repeatable>false</repeatable>
 					<label>Journal Title</label>
 					<input-type>onebox</input-type>
-					<hint>Examples: Foreign Affairs, PLOS One, Nature</hint>
+					<hint>Examples: Foreign Affairs, PLOS One, Nature; </hint>
 					<required></required>
 				</field>
 								
@@ -110,17 +178,6 @@
 				
 				<field>
 					<dc-schema>dc</dc-schema>
-					<dc-element>date</dc-element>
-					<dc-qualifier>issued</dc-qualifier>
-					<repeatable>false</repeatable>
-					<label>Date</label>
-					<input-type>date</input-type>
-					<hint>Enter date of previous publication or public distribution. A year is required, but month and day are optional. If the item has not been previously published, enter today's date. Examples: 2010, 1969 July 01, 1995 August</hint>
-					<required>You must enter at least the year.</required>
-				</field>
-				
-				<field>
-					<dc-schema>dc</dc-schema>
 					<dc-element>publisher</dc-element>
 					<dc-qualifier></dc-qualifier>
 					<repeatable>false</repeatable>
@@ -140,53 +197,7 @@
 					<hint>Enter the series and number assigned to this item. Examples: Virginia Cooperative Extension BSE-51NP, Airport Cooperative Research Program 124, TMC75-07-H-00008</hint>
 					<required></required>
 				</field>
-				
-				<field>
-					<dc-schema>dc</dc-schema>
-					<dc-element>identifier</dc-element>
-					<dc-qualifier></dc-qualifier>
-					<!-- An input-type of qualdrop_value MUST be marked as repeatable -->
-					<repeatable>true</repeatable>
-					<label>Identifiers</label>
-					<input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
-					<hint>If the item has any identification numbers or codes associated with it, please enter them. Examples: ISSN 0272-3638, DOI 10.1056/NEJMoa1510991, URL http://www.johncairns.net/ebook2.htm</hint>
-					<required></required>
-				</field>
-				
-				<field>
-					<dc-schema>dc</dc-schema>
-					<dc-element>language</dc-element>
-					<dc-qualifier>iso</dc-qualifier>
-					<repeatable>false</repeatable>
-					<label>Language</label>
-					<input-type value-pairs-name="common_iso_languages">dropdown</input-type>
-					<hint>Select the language of the main content of the item. If the language does not appear in the list, please select 'Other'. If the content does not really have a language (for example, if it is a dataset or an image) please select "N/A." Examples: English, French, Chinese</hint>
-					<required></required>
-				</field>
-				
-				<field>
-					<dc-schema>dc</dc-schema>
-					<dc-element>subject</dc-element>
-					<dc-qualifier></dc-qualifier>
-					<!-- An input-type of twobox MUST be marked as repeatable -->
-					<repeatable>true</repeatable>
-					<label>Subject Keywords</label>
-					<input-type>twobox</input-type>
-					<hint>Enter any keywords or phrases that describe the item's content. Enter each keyword or phrase separately, then click "Add." Repeat for all keywords or phrases. Examples: New River Valley, VA [Add], remote sensing [Add], photogrammetry [Add]</hint>
-					<required></required>
-				</field>
-				
-				<field>
-					<dc-schema>dc</dc-schema>
-					<dc-element>description</dc-element>
-					<dc-qualifier>abstract</dc-qualifier>
-					<repeatable>false</repeatable>
-					<label>Abstract</label>
-					<input-type>textarea</input-type>
-					<hint>Enter a brief summary of the item. Preferred length is a single paragraph or about 300 words, although you may enter an abstract of any length.</hint>
-					<required></required>
-				</field>
-				
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>description</dc-element>
@@ -197,7 +208,7 @@
 					<hint>Enter the names of any funders and/or grant numbers. Enter each funder name or grant number separately, then click "Add." Examples: National Science Foundation [Add], NSF: DMR-01-02277 [Add]</hint>
 					<required></required>
 				</field>
-				
+									
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>description</dc-element>


### PR DESCRIPTION
Added Volume, Issue, and Conference Title to default submission form and reordered elements. Still isn't as good as if we had a custom submission form for each item type -- looks weird. But oh well. 

dc.identifier.volume, dc.identifier.issue, and dc.description.notes. 
