### PR TITLE
Fix broken links on error pages

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/core/navigation.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/core/navigation.xsl
@@ -84,9 +84,9 @@
                  from under pageMeta. -->
                     <form id="ds-search-form" class="" method="post">
                         <xsl:attribute name="action">
-                            <xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath']"/>
+                            
                             <xsl:value-of
-                                    select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='search'][@qualifier='simpleURL']"/>
+                                    select="'/discover'"/>
                         </xsl:attribute>
                         <fieldset>
                             <div class="input-group">
@@ -113,7 +113,7 @@
                                                     select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath']"/>
                                             <xsl:text>/handle/&quot; + radio.value + &quot;</xsl:text>
                                             <xsl:value-of
-                                                    select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='search'][@qualifier='simpleURL']"/>
+                                                    select="'/discover'"/>
                                             <xsl:text>&quot; ; </xsl:text>
                                                     <xsl:text>
                                                         }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/core/page-structure.xsl
@@ -427,8 +427,8 @@
                                 </xsl:when>
                                 <xsl:otherwise>
                                     <li>
-                                        <form style="display: inline" action="{/dri:document/dri:meta/dri:userMeta/
-                            dri:metadata[@element='identifier' and @qualifier='loginURL']}" method="get">
+                                        <form style="display: inline" action="/login"
+ method="get">
                                             <button class="navbar-toggle navbar-link">
                                             <b class="visible-xs glyphicon glyphicon-user" aria-hidden="true"/>
                                             </button>
@@ -479,8 +479,8 @@
                                 </xsl:when>
                                 <xsl:otherwise>
                                     <li>
-                                        <a href="{/dri:document/dri:meta/dri:userMeta/
-                            dri:metadata[@element='identifier' and @qualifier='loginURL']}">
+                                        <a href="/login"
+                           >
                                             <span class="hidden-xs">
                                                 <i18n:text>xmlui.dri2xhtml.structural.login</i18n:text>
                                             </span>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/preprocess/general.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/preprocess/general.xsl
@@ -105,7 +105,7 @@
         <pageMeta>
             <xsl:call-template name="copy-attributes"/>
             <xsl:apply-templates select="*[not(self::dri:trail)]"/>
-            <trail target="{$context-path}/">
+            <trail target="'/'">
                 <i18n:text catalogue="default">xmlui.general.dspace_home</i18n:text>
             </trail>
             <trail>
@@ -117,7 +117,7 @@
         <pageMeta>
             <xsl:call-template name="copy-attributes"/>
             <xsl:apply-templates select="*[not(self::dri:trail)]"/>
-            <trail target="{$context-path}/">
+            <trail target="'/'">
                 <i18n:text catalogue="default">xmlui.general.dspace_home</i18n:text>
             </trail>
             <trail>
@@ -129,7 +129,7 @@
         <pageMeta>
             <xsl:call-template name="copy-attributes"/>
             <xsl:apply-templates select="*[not(self::dri:trail)]"/>
-            <trail target="{$context-path}/">
+            <trail target="'/'">
                 <i18n:text catalogue="default">xmlui.general.dspace_home</i18n:text>
             </trail>
             <trail>
@@ -146,7 +146,7 @@
             <metadata element="framing" qualifier="modal">true</metadata>
         </xsl:if>
         <xsl:if test="not(dri:trail)">
-            <trail target="{$context-path}/">
+            <trail target="'/'">
                 <i18n:text catalogue="default">xmlui.general.dspace_home</i18n:text>
             </trail>
             <trail>

--- a/dspace/modules/xmlui/src/main/webapp/exception2dri.xslt
+++ b/dspace/modules/xmlui/src/main/webapp/exception2dri.xslt
@@ -69,7 +69,7 @@ Created by Tim Donohue
           <metadata element="contextPath"><xsl:value-of select="$contextPath"/></metadata>
           <metadata element="title"><xsl:value-of select="$pageTitle"/></metadata>
           <trail>
-            <xsl:attribute name="target"><xsl:value-of select="$contextPath"/></xsl:attribute>
+            <xsl:attribute name="target"><xsl:value-of select="'/'"/></xsl:attribute>
             <i18n:text>xmlui.general.dspace_home</i18n:text>
           </trail>
         </pageMeta>

--- a/dspace/modules/xmlui/src/main/webapp/exception2html.xslt
+++ b/dspace/modules/xmlui/src/main/webapp/exception2html.xslt
@@ -88,7 +88,7 @@ Scott Phillips adapted it for Manakin's need.
 
         <h1><xsl:value-of select="$pageTitle"/></h1>
         <p class="home">
-          <a><xsl:attribute name="href"><xsl:value-of select="$contextPath"/>/</xsl:attribute><i18n:text>xmlui.general.go_home</i18n:text></a>
+          <a><xsl:attribute name="href"><xsl:value-of select="'/'"/></xsl:attribute><i18n:text>xmlui.general.go_home</i18n:text></a>
         </p>
 
         <p class="message">


### PR DESCRIPTION
This is a fix for GitHub issue #264
Incorrect links and non-functioning search box on error page

This adjusts login, home, and discovery links to work on pages
without the complete context, including DSpace error pages.

It's unlikely that we will ever add additional path components to the
VTechWorks urls, for example, changing https://vtechworks.lib.vt.edu/ to
https://vtechworks.lib.vt.edu/papers/, but if we do we will need to revisit
this issue.
