### PR TITLE
Fixed color of link in mobile breadcrumb bar

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_general.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_general.scss
@@ -235,7 +235,7 @@ header {
         margin-bottom: 0px;
         border: none;
     }
-    
+
 	.navbar-brand img{
         // increase logo size
 		height: 50px;
@@ -329,7 +329,9 @@ header {
     .breadcrumb{
         background-color: transparent;
         margin-bottom: 0;
-
+        > a  {
+            color: white;
+        }
         > li {
             color: white;
             > a  {


### PR DESCRIPTION
Added white text styling to immediate child elements of `trail-wrapper.breadcrumb` in the mirage2 custom SASS file. Tested on local server. Resolves issue #262.
