### PR TITLE
Bitstream metadata search results

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/discovery/discovery.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/discovery/discovery.xsl
@@ -182,10 +182,11 @@
                     <h4>
                         <xsl:choose>
                             <xsl:when test="dri:list[@n=(concat($handle, ':dc.title'))]">
-                            	<!--
+
                                 <xsl:apply-templates select="dri:list[@n=(concat($handle, ':dc.title'))]/dri:item"/>
-                                -->
-                                <xsl:value-of select="dri:list[@n=(concat($handle, ':dc.title'))]/dri:item" disable-output-escaping="yes"/>
+
+                              <!--  <xsl:value-of select="dri:list[@n=(concat($handle, ':dc.title'))]/dri:item" disable-output-escaping="yes"/>
+-->
                             </xsl:when>
                             <xsl:otherwise>
                                 <i18n:text>xmlui.dri2xhtml.METS-1.0.no-title</i18n:text>
@@ -298,15 +299,15 @@
                             </div>
                         </xsl:when>
                         <xsl:when test="dri:list[@n=(concat($handle, ':fulltext'))]">
-                          <div>Search phrase found in item's original documents
+
+
+                          <div>Search term found in file metadata
                             <btn class="btn btn-primary btn-xs collapsed" data-toggle="collapse">
                               <xsl:attribute name="data-target">
                                 <xsl:value-of select="concat('#result-', translate($handle,'/','-'))"/>
                               </xsl:attribute>
                               <xsl:value-of select="'View Excerpt'"/>
                             </btn>
-
-
                           </div>
 
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/discovery/discovery.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/discovery/discovery.xsl
@@ -254,7 +254,7 @@
                             <span class="publisher">
                             	<xsl:if test="dri:list[@n=(concat($handle, ':dc.publisher'))]">
                                 	<!-- Separates multiple publishers -->
-                                	<!--  
+                                	<!--
                                     <xsl:apply-templates select="dri:list[@n=(concat($handle, ':dc.publisher'))]/dri:item"/>
                                     -->
 									<xsl:for-each select="dri:list[@n=(concat($handle, ':dc.publisher'))]/dri:item">
@@ -268,10 +268,10 @@
                                 	</xsl:for-each>
                                 </xsl:if>
 							</span>
-                                <!--  
+                                <!--
                                 <xsl:text>, </xsl:text>
                                 -->
-                            
+
                             <span class="date">
                                 <xsl:value-of
                                         select="substring(dri:list[@n=(concat($handle, ':dc.date.issued'))]/dri:item,1,10)"/>
@@ -284,7 +284,7 @@
 						<span class="trnumber h4"><small>
 							<xsl:text>, </xsl:text>
 							<xsl:value-of select="dri:list[@n=(concat($handle, ':dc.identifier.trnumber'))]/dri:item"/>
-						</small></span>	
+						</small></span>
                 	</xsl:if>
                     <xsl:choose>
                         <xsl:when test="dri:list[@n=(concat($handle, ':dc.description.abstract'))]/dri:item/dri:hi">
@@ -298,7 +298,22 @@
                             </div>
                         </xsl:when>
                         <xsl:when test="dri:list[@n=(concat($handle, ':fulltext'))]">
-                            <div class="abstract">
+                          <div>Search phrase found in item's original documents
+                            <btn class="btn btn-primary btn-xs collapsed" data-toggle="collapse">
+                              <xsl:attribute name="data-target">
+                                <xsl:value-of select="concat('#result-', translate($handle,'/','-'))"/>
+                              </xsl:attribute>
+                              <xsl:value-of select="'View Excerpt'"/>
+                            </btn>
+
+
+                          </div>
+
+
+                            <div class="abstract collapse">
+                                <xsl:attribute name="id">
+                                  <xsl:value-of select="concat('result-', translate($handle,'/','-'))"/>
+                                </xsl:attribute>
                                 <xsl:for-each select="dri:list[@n=(concat($handle, ':fulltext'))]/dri:item">
                                     <xsl:apply-templates select="."/>
                                     <xsl:text>...</xsl:text>
@@ -452,7 +467,7 @@
         <xsl:text>
             if (!window.DSpace.i18n) {
                 window.DSpace.i18n = {};
-            } 
+            }
             if (!window.DSpace.i18n.discovery) {
                 window.DSpace.i18n.discovery = {};
             }


### PR DESCRIPTION
Made bitstream data collapsible and with an explanation
Addresses issue #146  
Example 

_Not clicked_
<img width="678" alt="screen shot 2016-06-17 at 3 52 54 pm" src="https://cloud.githubusercontent.com/assets/7339589/16162869/103849d0-34a4-11e6-8d5c-35bef85eed4e.png">  
_Clicked_
<img width="653" alt="screen shot 2016-06-17 at 3 53 13 pm" src="https://cloud.githubusercontent.com/assets/7339589/16162890/335f5746-34a4-11e6-9a98-deba32accd53.png">
