### PR TITLE
Accessibility fixes [Messed up]

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_bootstrap_variables.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_bootstrap_variables.scss
@@ -13,7 +13,14 @@
 $chicago-maroon: #660000;
 $burnt-orange: #ff6600;
 
+// Web accessibility 2.0 compatible colors
+$gray-on-almost-white-aim: #494949;
+$gray-on-white-aim: #4c4c4c;
+
 $brand-primary: $chicago-maroon;
 
-$navbar-inverse-bg: $chicago-maroon; 
+$navbar-inverse-bg: $chicago-maroon;
 $navbar-inverse-link-color: white;
+
+$text-muted: $gray-on-white-aim;
+$gray-light: $gray-on-white-aim;

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_general.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_general.scss
@@ -5,6 +5,10 @@
  *
  * http://www.dspace.org/license/
  */
+
+body {
+  color:#1a1a1a;
+}
 .first-page-header {
     margin-top: 0;
 }
@@ -16,7 +20,9 @@
 dl {
     margin: 0;
 }
-
+#aspect_browseArtifacts_CommunityBrowse_div_community-browse h3, #aspect_browseArtifacts_CollectionBrowse_div_collection-browse h3 {
+    color: $gray-light !important;
+}
 #ds-options h1,
 #ds-options h2,
 #ds-options h3,

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/discovery/discovery.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/discovery/discovery.xsl
@@ -254,7 +254,7 @@
                             <span class="publisher">
                             	<xsl:if test="dri:list[@n=(concat($handle, ':dc.publisher'))]">
                                 	<!-- Separates multiple publishers -->
-                                	<!--  
+                                	<!--
                                     <xsl:apply-templates select="dri:list[@n=(concat($handle, ':dc.publisher'))]/dri:item"/>
                                     -->
 									<xsl:for-each select="dri:list[@n=(concat($handle, ':dc.publisher'))]/dri:item">
@@ -268,10 +268,10 @@
                                 	</xsl:for-each>
                                 </xsl:if>
 							</span>
-                                <!--  
+                                <!--
                                 <xsl:text>, </xsl:text>
                                 -->
-                            
+
                             <span class="date">
                                 <xsl:value-of
                                         select="substring(dri:list[@n=(concat($handle, ':dc.date.issued'))]/dri:item,1,10)"/>
@@ -284,7 +284,7 @@
 						<span class="trnumber h4"><small>
 							<xsl:text>, </xsl:text>
 							<xsl:value-of select="dri:list[@n=(concat($handle, ':dc.identifier.trnumber'))]/dri:item"/>
-						</small></span>	
+						</small></span>
                 	</xsl:if>
                     <xsl:choose>
                         <xsl:when test="dri:list[@n=(concat($handle, ':dc.description.abstract'))]/dri:item/dri:hi">
@@ -298,7 +298,22 @@
                             </div>
                         </xsl:when>
                         <xsl:when test="dri:list[@n=(concat($handle, ':fulltext'))]">
-                            <div class="abstract">
+                          <div>Search phrase found in item's original documents
+                            <btn class="btn btn-primary btn-xs collapsed" data-toggle="collapse">
+                              <xsl:attribute name="data-target">
+                                <xsl:value-of select="concat('#result-', translate($handle,'/','-'))"/>
+                              </xsl:attribute>
+                              <xsl:value-of select="'View Excerpt'"/>
+                            </btn>
+
+
+                          </div>
+
+
+                            <div class="abstract collapse">
+                                <xsl:attribute name="id">
+                                  <xsl:value-of select="concat('result-', translate($handle,'/','-'))"/>
+                                </xsl:attribute>
                                 <xsl:for-each select="dri:list[@n=(concat($handle, ':fulltext'))]/dri:item">
                                     <xsl:apply-templates select="."/>
                                     <xsl:text>...</xsl:text>
@@ -452,7 +467,7 @@
         <xsl:text>
             if (!window.DSpace.i18n) {
                 window.DSpace.i18n = {};
-            } 
+            }
             if (!window.DSpace.i18n.discovery) {
                 window.DSpace.i18n.discovery = {};
             }


### PR DESCRIPTION
Made the various gray shades minimally darker so that they pass W3C AAA contrast standards.
Also darkened body text slightly, since the darker grey shades had made it harder to distinguish content text with has gray info text above it.
Addresses issue #21
