### PR TITLE
Accessibility Font Contrast

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_bootstrap_variables.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_bootstrap_variables.scss
@@ -13,7 +13,14 @@
 $chicago-maroon: #660000;
 $burnt-orange: #ff6600;
 
+// Web accessibility 2.0 compatible colors
+$gray-on-almost-white-aim: #494949;
+$gray-on-white-aim: #4c4c4c;
+
 $brand-primary: $chicago-maroon;
 
-$navbar-inverse-bg: $chicago-maroon; 
+$navbar-inverse-bg: $chicago-maroon;
 $navbar-inverse-link-color: white;
+
+$text-muted: $gray-on-white-aim;
+$gray-light: $gray-on-white-aim;

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_general.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_general.scss
@@ -5,6 +5,10 @@
  *
  * http://www.dspace.org/license/
  */
+
+body {
+  color:#1a1a1a;
+}
 .first-page-header {
     margin-top: 0;
 }
@@ -16,7 +20,9 @@
 dl {
     margin: 0;
 }
-
+#aspect_browseArtifacts_CommunityBrowse_div_community-browse h3, #aspect_browseArtifacts_CollectionBrowse_div_collection-browse h3 {
+    color: $gray-light !important;
+}
 #ds-options h1,
 #ds-options h2,
 #ds-options h3,


### PR DESCRIPTION
Made the various gray shades minimally darker so that they pass W3C AAA contrast standards.
Also darkened body text slightly, since the darker grey shades had made it harder to distinguish content text with has gray info text above it.
Addresses issue #21
