### PR TITLE
Sherpa Romeo message text-wrap fixed

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/submission/submission.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/submission/submission.xsl
@@ -111,12 +111,35 @@
             </xsl:attribute>
 
             <i18n:text>
-                <xsl:value-of select="."/>
+                <xsl:if test="contains(@rend,'white')">
+                    <xsl:text>white</xsl:text>
+                </xsl:if>
+                <xsl:if test="contains(@rend,'blue')">
+                    <xsl:text>blue</xsl:text>
+                </xsl:if>
+                <xsl:if test="contains(@rend,'yellow')">
+                    <xsl:text>yellow</xsl:text>
+                </xsl:if>
+                <xsl:if test="contains(@rend,'green')">
+                    <xsl:text>green</xsl:text>
+                </xsl:if>
+                <xsl:if test="contains(@rend,'gray')">
+                    <xsl:text>gray</xsl:text>
+                </xsl:if>                
             </i18n:text>
         </span>
+        
+        <div>
+            <i18n:text>
+                <xsl:value-of select="."/>
+            </i18n:text>
+        </div>
+
+   
+       
         <span><xsl:text> </xsl:text></span>
     </xsl:template>
-
+       
     <xsl:template match="dri:list[@rend='sherpaList']/dri:item/dri:figure" priority="2" >
         <a>
             <xsl:attribute name="href"><xsl:value-of select="@target"/></xsl:attribute>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2484,8 +2484,8 @@
     <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
     <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
     <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
-    <message key="xmlui.aspect.sherpa.submission.green">You may deposit a draft version, submitted version (pre peer review), or accepted version (post peer review) of your work; you may also be allowed or required to deposit the publisher's version (final typeset PDF)</message>
-    <message key="xmlui.aspect.sherpa.submission.blue">You may deposit an accepted version (post peer review) of your work; you may also be allowed or required to deposit the publisher's version (final typeset PDF)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">You may deposit a draft version, submitted version (pre peer review), or accepted version (post peer review) of your work; you might also be allowed or required to deposit the publisher's version (final typeset PDF)</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">You may deposit an accepted version (post peer review) of your work; you might also be allowed or required to deposit the publisher's version (final typeset PDF)</message>
     <message key="xmlui.aspect.sherpa.submission.yellow">You may deposit a draft version or submitted version (pre peer review) of your work</message>
     <message key="xmlui.aspect.sherpa.submission.white">You may not deposit any version of your work</message>
     <message key="xmlui.aspect.sherpa.submission.gray">Deposit policies are unknown</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2484,11 +2484,11 @@
     <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
     <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
     <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
-    <message key="xmlui.aspect.sherpa.submission.green">green - you may deposit a draft version, submitted version (pre peer review), or accepted version (post peer review) of your work; you might also be allowed or required to deposit the publisher's version (final typeset PDF)</message>
-    <message key="xmlui.aspect.sherpa.submission.blue">blue - you may deposit an accepted version (post peer review) of your work; you might also be allowed or required to deposit the publisher's version (final typeset PDF)</message>
-    <message key="xmlui.aspect.sherpa.submission.yellow">yellow - you may deposit a draft version or submitted version (pre peer review) of your work</message>
-    <message key="xmlui.aspect.sherpa.submission.white">white - you may not deposit any version of your work</message>
-    <message key="xmlui.aspect.sherpa.submission.gray">gray - deposit policies are unknown</message>
+    <message key="xmlui.aspect.sherpa.submission.green">You may deposit a draft version, submitted version (pre peer review), or accepted version (post peer review) of your work; you may also be allowed or required to deposit the publisher's version (final typeset PDF)</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">You may deposit an accepted version (post peer review) of your work; you may also be allowed or required to deposit the publisher's version (final typeset PDF)</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">You may deposit a draft version or submitted version (pre peer review) of your work</message>
+    <message key="xmlui.aspect.sherpa.submission.white">You may not deposit any version of your work</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">Deposit policies are unknown</message>
 
     <!-- End Versioning -->
 


### PR DESCRIPTION
Made Romeo color text in its own label and moved description to a new line outside of any label. Works for all colors. 
Addresses issue #304
