### PR TITLE
ClamAV scanning for both submissions and a curation task

### DIFF
--- a/dspace/config/modules/clamav.cfg
+++ b/dspace/config/modules/clamav.cfg
@@ -11,12 +11,12 @@ service.host = 127.0.0.1
 service.port = 3310
 
 # Initial timeout value (in milliseconds) used when the socket is connecting
-socket.timeout = 120
+socket.timeout = 5000
 
 # Flag indicating whether a scan should stop when the first infected bitstream
 # is detected within an item. Normally a complete scan is desired, so default
 # value is false. But if items can contain large numbers of bitstreams, the
 # display of the results can become unwieldy.
-scan.failfast = false
+scan.failfast = true
 
 

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -12,7 +12,8 @@ plugin.named.org.dspace.curate.CurationTask = \
     org.dspace.ctask.general.RequiredMetadata = requiredmetadata, \
     org.dspace.ctask.general.ClamScan = vscan, \
     org.dspace.ctask.general.MicrosoftTranslator = translate, \
-    org.dspace.ctask.general.MetadataValueLinkChecker = checklinks
+    org.dspace.ctask.general.MetadataValueLinkChecker = checklinks, \
+
 # add new tasks here
 
 ## task queue implementation
@@ -30,7 +31,8 @@ taskqueue.dir = ${dspace.dir}/ctqueues
 ui.tasknames = \
      profileformats = Profile Bitstream Formats, \
      requiredmetadata = Check for Required Metadata, \
-     checklinks = Check Links in Metadata
+     checklinks = Check Links in Metadata, \
+     vscan = Scan for Viruses
 
 # Tasks may be organized into named groups which display together in UI drop-downs
 # ui.taskgroups = \

--- a/dspace/config/modules/submission-curation.cfg
+++ b/dspace/config/modules/submission-curation.cfg
@@ -5,4 +5,4 @@
 # to the scheduling of curation tasks during submission.        #
 #---------------------------------------------------------------#
 # Scan for viruses
-virus-scan = false
+virus-scan = true


### PR DESCRIPTION
Addresses issue #307

**My local clamAV settings had:**
maxFileSize 100M
maxScanSize 100M
StreamMaxLength 100M
MaxZipTypeRcg 3M

Everything else to defaults

**I tested submission uploads on local server and got desired results for the following:**
Test files in Google Drive/Technology/ClamAV Test Files/ 
90 MB DMG file
2-10 MB PDFs
97 MB PDF
Test infected file - upload prevented
88 MB ZIP containing PDFs 

Curation virus scanning task also worked for the above  
