### PR TITLE
Removed search and workflow stats link from homepage

### DIFF
--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -16,9 +16,9 @@ resolver.timeout = 200
 #View/download statistics
 authorization.admin.usage=false
 #Search/search result statistics
-authorization.admin.search=false
+authorization.admin.search=true
 #Workflow result statistics
-authorization.admin.workflow=false
+authorization.admin.workflow=true
 
 # Enable/disable logging of spiders in solr statistics.
 # If false, and IP matches an address in spiderips.urls, event is not logged.


### PR DESCRIPTION
Regular users no longer see workflow or search statistics link on homepage (or anywhere).
Link to homepage statistics remains.
Resolves issue #316
