### PR TITLE
Move abstract, subject, notes, article fields to page 2 of submission form

### DIFF
--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -52,7 +52,7 @@
 					<hint>Select the type(s) of content you are depositing. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" or "COMMAND" key. Examples: Article, Learning Object, Video Recording and Presentation. </hint>
 					<required></required>
 				</field>
-			
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>contributor</dc-element>
@@ -63,7 +63,7 @@
 					<hint>Enter the name(s) of the author(s) or creator(s). Enter each name individually, then click "Add". To use VTechWorks' name lookup function, click "Lookup" and you will be directed to an index of VTechWorks' creator and contributor names. Examples: Faulkner, William; Einstein, Albert; Lovelace, Ada</hint>
 					<required></required>
 				</field>
-				
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>title</dc-element>
@@ -74,7 +74,7 @@
 					<hint>Enter the title or name of the item. If a title is not provided, create one that appropriately describes the item. Examples: Extended Boolean Information Retrieval, Ossian and the Genres of Culture, Chemistry of Arsenic Removal During Coagulation and Fe-Mn Oxidation</hint>
 					<required>You must enter a main title for this item.</required>
 				</field>
-				
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>date</dc-element>
@@ -84,8 +84,77 @@
 					<input-type>date</input-type>
 					<hint>Enter date of previous publication or public distribution. A year is required, but month and day are optional. If the item has not been previously published, enter today's date. Examples: 2010, 1969 July 01, 1995 August</hint>
 					<required>You must enter at least the year.</required>
-				</field>				
-				
+				</field>
+
+				<field>
+					<dc-schema>dc</dc-schema>
+					<dc-element>identifier</dc-element>
+					<dc-qualifier></dc-qualifier>
+					<!-- An input-type of qualdrop_value MUST be marked as repeatable -->
+					<repeatable>true</repeatable>
+					<label>Identifiers</label>
+					<input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
+					<hint>If the item has any identification numbers or codes associated with it, please enter them. Examples: DOI 10.1056/NEJMoa1510991, URL http://www.johncairns.net/ebook2.htm, ISSN 0272-3638</hint>
+					<required></required>
+				</field>
+
+				<field>
+					<dc-schema>dc</dc-schema>
+					<dc-element>language</dc-element>
+					<dc-qualifier>iso</dc-qualifier>
+					<repeatable>false</repeatable>
+					<label>Language</label>
+					<input-type value-pairs-name="common_iso_languages">dropdown</input-type>
+					<hint>Select the language of the main content of the item. If the language does not appear in the list, please select 'Other'. If the content does not really have a language (for example, if it is a dataset or an image) please select "N/A." Examples: English, French, Chinese</hint>
+					<required></required>
+				</field>
+
+				<field>
+					<dc-schema>dc</dc-schema>
+					<dc-element>relation</dc-element>
+					<dc-qualifier>ispartof</dc-qualifier>
+					<repeatable>false</repeatable>
+					<label>Conference Title</label>
+					<input-type>onebox</input-type>
+					<hint>Examples: Modern Language Association Annual Meeting, 2016 IEEE International Symposium on Circuits and Systems, Veterans in Society 2015.</hint>
+					<required></required>
+				</field>
+
+				<field>
+					<dc-schema>dc</dc-schema>
+					<dc-element>publisher</dc-element>
+					<dc-qualifier></dc-qualifier>
+					<repeatable>false</repeatable>
+					<label>Publisher</label>
+					<input-type>onebox</input-type>
+					<hint>If the item has been published or accepted for publication, enter the publisher. If the item has not been published, enter "Virginia Tech." Examples: Wiley, Cornell University Press, Taylor &amp; Francis</hint>
+					<required></required>
+				</field>
+
+				<field>
+					<dc-schema>dc</dc-schema>
+					<dc-element>relation</dc-element>
+					<dc-qualifier>ispartofseries</dc-qualifier>
+					<repeatable>true</repeatable>
+					<label>Series/Report Number</label>
+					<input-type>series</input-type>
+					<hint>Enter the series and number assigned to this item. Examples: Virginia Cooperative Extension BSE-51NP, Airport Cooperative Research Program 124, TMC75-07-H-00008</hint>
+					<required></required>
+				</field>
+
+				<field>
+					<dc-schema>dc</dc-schema>
+					<dc-element>description</dc-element>
+					<dc-qualifier>sponsorship</dc-qualifier>
+					<repeatable>true</repeatable>
+					<label>Funding</label>
+					<input-type>onebox</input-type>
+					<hint>Enter the names of any funders and/or grant numbers. Enter each funder name or grant number separately, then click "Add." Examples: National Science Foundation [Add], NSF: DMR-01-02277 [Add]</hint>
+					<required></required>
+				</field>
+			</page>
+
+			<page number="2">
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>description</dc-element>
@@ -111,104 +180,40 @@
 
 				<field>
 					<dc-schema>dc</dc-schema>
-					<dc-element>identifier</dc-element>
-					<dc-qualifier></dc-qualifier>
-					<!-- An input-type of qualdrop_value MUST be marked as repeatable -->
-					<repeatable>true</repeatable>
-					<label>Identifiers</label>
-					<input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
-					<hint>If the item has any identification numbers or codes associated with it, please enter them. Examples: DOI 10.1056/NEJMoa1510991, URL http://www.johncairns.net/ebook2.htm, ISSN 0272-3638</hint>
-					<required></required>
-				</field>
-
-				<field>
-					<dc-schema>dc</dc-schema>
-					<dc-element>language</dc-element>
-					<dc-qualifier>iso</dc-qualifier>
-					<repeatable>false</repeatable>
-					<label>Language</label>
-					<input-type value-pairs-name="common_iso_languages">dropdown</input-type>
-					<hint>Select the language of the main content of the item. If the language does not appear in the list, please select 'Other'. If the content does not really have a language (for example, if it is a dataset or an image) please select "N/A." Examples: English, French, Chinese</hint>
-					<required></required>
-				</field>
-				
-				<field>
-					<dc-schema>dc</dc-schema>
-					<dc-element>relation</dc-element>
-					<dc-qualifier>ispartof</dc-qualifier>
-					<repeatable>false</repeatable>
-					<label>Conference Title</label>
-					<input-type>onebox</input-type>
-					<hint>Examples: Modern Language Association Annual Meeting, 2016 IEEE International Symposium on Circuits and Systems, Veterans in Society 2015.</hint>
-					<required></required>
-				</field>
-			
-				<field>
-					<dc-schema>dc</dc-schema>
 					<dc-element>title</dc-element>
 					<dc-qualifier>serial</dc-qualifier>
 					<repeatable>false</repeatable>
 					<label>Journal Title</label>
+					<type-bind>Article</type-bind>
 					<input-type>onebox</input-type>
 					<hint>Examples: Foreign Affairs, PLOS One, Nature</hint>
 					<required></required>
 				</field>
-								
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>identifier</dc-element>
 					<dc-qualifier>volume</dc-qualifier>
 					<repeatable>false</repeatable>
 					<label>Volume</label>
+					<type-bind>Article</type-bind>
 					<input-type>onebox</input-type>
 					<hint>Examples: 29, XVI, 1999</hint>
 					<required></required>
 				</field>
-				
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>identifier</dc-element>
 					<dc-qualifier>issue</dc-qualifier>
 					<repeatable>false</repeatable>
 					<label>Issue</label>
+					<type-bind>Article</type-bind>
 					<input-type>onebox</input-type>
 					<hint>Examples: 4, 2, Summer</hint>
 					<required></required>
-				</field>			
-				
-				<field>
-					<dc-schema>dc</dc-schema>
-					<dc-element>publisher</dc-element>
-					<dc-qualifier></dc-qualifier>
-					<repeatable>false</repeatable>
-					<label>Publisher</label>
-					<input-type>onebox</input-type>
-					<hint>If the item has been published or accepted for publication, enter the publisher. If the item has not been published, enter "Virginia Tech." Examples: Wiley, Cornell University Press, Taylor &amp; Francis</hint>
-					<required></required>
 				</field>
 				
-				<field>
-					<dc-schema>dc</dc-schema>
-					<dc-element>relation</dc-element>
-					<dc-qualifier>ispartofseries</dc-qualifier>
-					<repeatable>true</repeatable>
-					<label>Series/Report Number</label>
-					<input-type>series</input-type>
-					<hint>Enter the series and number assigned to this item. Examples: Virginia Cooperative Extension BSE-51NP, Airport Cooperative Research Program 124, TMC75-07-H-00008</hint>
-					<required></required>
-				</field>
-
-				<field>
-					<dc-schema>dc</dc-schema>
-					<dc-element>description</dc-element>
-					<dc-qualifier>sponsorship</dc-qualifier>
-					<repeatable>true</repeatable>
-					<label>Funding</label>
-					<input-type>onebox</input-type>
-					<hint>Enter the names of any funders and/or grant numbers. Enter each funder name or grant number separately, then click "Add." Examples: National Science Foundation [Add], NSF: DMR-01-02277 [Add]</hint>
-					<required></required>
-				</field>
-									
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>description</dc-element>
@@ -219,9 +224,7 @@
 					<hint>Enter any additional information that will help describe the item.</hint>
 					<required></required>
 				</field>
-</page>
-			
-			<page number="2">
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>title</dc-element>
@@ -233,7 +236,7 @@
 					<hint>If the item has any alternative titles, please enter them here.</hint>
 					<required></required>
 				</field>
-				
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>identifier</dc-element>
@@ -245,7 +248,7 @@
 					<hint>Enter the standard citation for the previously issued instance of this item.</hint>
 					<required></required>
 				</field>
-				
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>relation</dc-element>
@@ -257,7 +260,7 @@
 					<hint>If the item is an episode in a series or compilation, enter the item's episode title here.</hint>
 					<required></required>
 				</field>
-				
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>date</dc-element>
@@ -267,9 +270,9 @@
 					<type-bind>Audio recording,Video recording</type-bind>
 					<input-type>date</input-type>
 					<hint>Enter the date when the item was created. For interview, enter the date when the raw interview was conducted.</hint>
-					<required>You must enter at least the year.</required>
+					<required></required>
 				</field>
-				
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>contributor</dc-element>
@@ -281,7 +284,7 @@
 					<hint>Enter the name of the person(s) responsible for the general management and supervision of a filmed performance, radio or television program, etc.</hint>
 					<required></required>
 				</field>
-				
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>contributor</dc-element>
@@ -293,7 +296,7 @@
 					<hint>Enter the name of the person or organization responsible for assembling, arranging, and trimming film, video, or other moving image formats, including both visual and audio components.</hint>
 					<required></required>
 				</field>
-				
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>contributor</dc-element>
@@ -305,7 +308,7 @@
 					<hint>For interviews, enter the name of the person who was interviewed.</hint>
 					<required></required>
 				</field>
-				
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>contributor</dc-element>
@@ -317,7 +320,7 @@
 					<hint>For interviews, enter the name of the person(s) who conducted the interview.</hint>
 					<required></required>
 				</field>
-				
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>contributor</dc-element>
@@ -329,7 +332,7 @@
 					<hint>Enter the name(s) of an entity or entities responsible for making contributions to the resource.</hint>
 					<required></required>
 				</field>
-				
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>format</dc-element>
@@ -341,7 +344,7 @@
 					<hint>Enter the length or duration of the resource. Represents the playback time. Format: HH:MM:SS (Example: 02:33:53 for a film that is 2 hours, 33 minutes, and 53 seconds)</hint>
 					<required></required>
 				</field>
-				
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>description</dc-element>
@@ -353,7 +356,7 @@
 					<hint>If available, provide a textual transcription of the item.</hint>
 					<required></required>
 				</field>
-				
+
 				<field>
 					<dc-schema>dc</dc-schema>
 					<dc-element>rights</dc-element>
@@ -365,7 +368,6 @@
 					<hint>Enter the name of the person or organization that owns or manages rights over the item you are submitting. Enter organization names in the "Last Name" field.</hint>
 					<required></required>
 				</field>
-				
 			</page>
 		</form>
 


### PR DESCRIPTION
Move abstract, subject, and notes fields to page 2 of submission form so page won't be blank.
Move article specific fields to page 2 and bind them to article content-type.
Make date created field optional. 

Page 1 of submission form
![submissionformpage1](https://cloud.githubusercontent.com/assets/13037168/16698785/0e696f5a-451e-11e6-88fc-04d1f391c1cc.png)

Page 2 of submission form if article is selected
![submissionformpage2article](https://cloud.githubusercontent.com/assets/13037168/16698848/774759e2-451e-11e6-98ab-a265ef744dac.png)

Page 2 of submission form if audio or video is selected
![submissionformpage2video](https://cloud.githubusercontent.com/assets/13037168/16698857/84cf6c58-451e-11e6-9146-9d26fb8453cb.png)

Page 2 of submission form if article, audio, or video are not selected
![submissionformpage2book](https://cloud.githubusercontent.com/assets/13037168/16698805/2fb91a52-451e-11e6-8ffc-8ad026e68648.png)
