### PR TITLE
Metadata cutoff fix

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/_style.scss
@@ -41,6 +41,9 @@ padding: 2px;
     @media (max-width: $screen-xs-max) {
         overflow-x: auto;
     }
+    .word-break {
+        word-break:break-word;
+    }
 }
 
 .word-break {

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_general.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_general.scss
@@ -122,14 +122,30 @@ dl {
     font-weight: bold;
 }
 
+
 .ds-table-responsive {
+    
     @media (max-width: $screen-xs-max) {
         overflow-x: auto;
         .word-break {
             min-width: 300px;
         }
     }
+    table {
+        width: 100%;
+        table-layout: fixed;
+        tr {
+            td {
+            
+                overflow:hidden;
+                word-wrap:break-word;
+                white-space:pre-wrap
+            }
+        }
+    }
+     
 }
+
 
 .table legend {
     display: none;

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_general.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_general.scss
@@ -122,30 +122,14 @@ dl {
     font-weight: bold;
 }
 
-
 .ds-table-responsive {
-    
     @media (max-width: $screen-xs-max) {
         overflow-x: auto;
         .word-break {
             min-width: 300px;
         }
     }
-    table {
-        width: 100%;
-        table-layout: fixed;
-        tr {
-            td {
-            
-                overflow:hidden;
-                word-wrap:break-word;
-                white-space:pre-wrap
-            }
-        }
-    }
-     
 }
-
 
 .table legend {
     display: none;

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_general.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_general.scss
@@ -129,16 +129,7 @@ dl {
             min-width: 300px;
         }
     }
-    tr {
-        td {
-        
-            overflow:hidden;
-            word-wrap:break-word;
-            white-space:pre-wrap
-        }
-    }
 }
-
 
 .table legend {
     display: none;

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_general.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/styles/classic_mirage_color_scheme/_general.scss
@@ -129,7 +129,16 @@ dl {
             min-width: 300px;
         }
     }
+    tr {
+        td {
+        
+            overflow:hidden;
+            word-wrap:break-word;
+            white-space:pre-wrap
+        }
+    }
 }
+
 
 .table legend {
     display: none;

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -550,7 +550,7 @@
                 </td>
                 <!-- Item full view enabling html for all fields, e.g., abstract -->
                 <!-- Render abstract by line break -->
-	            <td class="word-break line-break">
+	            <td class="word-break">
 	              <!--  
 	              <xsl:copy-of select="./node()"/>
 	              -->


### PR DESCRIPTION
For issue #331. Fields were cut off because of long url's - old CSS didn't make line breaks anywhere but at whitespace. 
Unfortunately my fix involves fixed width columns. I might be able to do something with CSS's @media capabilities for a better looking solution. 

<img width="400" alt="screen shot 2016-07-14 at 10 57 51 am" src="https://cloud.githubusercontent.com/assets/7339589/16844248/62b678d0-49b2-11e6-96e5-ef7564cb9c6e.png">
