### PR TITLE
Appended "invited?" string to c-invited field

### DIFF
--- a/dspace/config/crosswalks/symplectic_xwalks_dspace_default.xsl
+++ b/dspace/config/crosswalks/symplectic_xwalks_dspace_default.xsl
@@ -54,7 +54,7 @@
         <crosswalks:mapping dspace="dc.description.notes" elements="fulltext-comment,notes" />
         <crosswalks:mapping dspace="dc.description.notes" format-elements="~[$publication-status] (Publication status)~" />
         <crosswalks:mapping dspace="dc.description.notes" format-elements="~[$c-review-type:list(, )] (Peer reviewed?)~" />
-        <crosswalks:mapping dspace="dc.description.notes" elements="c-invited" />
+        <crosswalks:mapping dspace="dc.description.notes" elements="~[c-invited] (invited?)" />
         <crosswalks:mapping dspace="dc.description.provenance" elements="addresses,record-created-at-source-date" />
         <crosswalks:mapping dspace="dc.description.provenance" elements="~[$are-files-confidential] (Are files confidential?)" />
         <crosswalks:mapping dspace="dc.description.provenance" elements="~[$confidential] (Confidential?)" />


### PR DESCRIPTION
Hi there, with Andrew's help, I was able to successfully revise the "c-invited" field so that metadata about presentations and conference items that were NOT invited would not appear, but _would_ appear if the presentation or conference item WAS invited. 

Unfortunately, as of now only the word "true" appears in the "dc.description.notes[en_US]" field, which doesn't provide the user with any context. I've appended the string "(invited?)" to the "dc.description.notes[en_US]" field that "c-invited" is mapped to; hopefully this will improve things. Thanks so much, and take care.
