### PR TITLE
Add orcid, reorder content_type and modify emabargo message

### DIFF
--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -889,6 +889,10 @@
 				<stored-value>issn</stored-value>
 			</pair>
 			<pair>
+				<displayed-value>ORCID</displayed-value>
+				<stored-value>orcid</stored-value>
+			</pair>
+			<pair>
 				<displayed-value>URL (web link)</displayed-value>
 				<stored-value>url</stored-value>
 			</pair>
@@ -940,12 +944,12 @@
 				<stored-value>Presentation</stored-value>
 			</pair>
 			<pair>
-				<displayed-value>Software</displayed-value>
-				<stored-value>Software</stored-value>
-			</pair>
-			<pair>
 				<displayed-value>Report</displayed-value>
 				<stored-value>Report</stored-value>
+			</pair>
+			<pair>
+				<displayed-value>Software</displayed-value>
+				<stored-value>Software</stored-value>
 			</pair>
 			<pair>
 				<displayed-value>Thesis</displayed-value>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -794,7 +794,7 @@
     <message key="xmlui.Submission.submit.AccessStep.name_help">A short, descriptive name for the policy (up to 30 characters). May be shown to end users. Example: "Staff-only". Optional but recommended.</message>
     <message key="xmlui.Submission.submit.AccessStep.description">Description</message>
     <message key="xmlui.Submission.submit.AccessStep.reason">Embargo reason</message>
-    <message key="xmlui.Submission.submit.AccessStep.reason_help">The reason you would like the file to remain private for a certain period (embargoed). The embargo reason is not shown anywhere in the public record of the item: it is for administrator use only. Examples: Awaiting publication, Applying for a patent, File contains personally identifiable information.</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">The reason you would like the file to remain private for a certain period (embargoed). The embargo reason is not shown anywhere in the public record of the item: it is for administrator use only. Examples: Awaiting publication, Applying for a patent.</message>
     <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Confirm Policy &amp; add another</message>
     <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Group</message>
     <message key="xmlui.Submission.submit.AccessStep.error_format_date">Error format date</message>


### PR DESCRIPTION
Resolved Issue #385: changes to input-forms.xml - Added a new value 'ORCID' to the common_identifiers; reordered 'Report' and 'Software' in common_types to show it alphabetically
Resolved Issue #386: changes to messages.xml- Modified the embargo reasons to remove the 'File contains personally identifiable information'
