### PR TITLE
Increased ClamAV socket timeout to 120 seconds

### DIFF
--- a/dspace/config/modules/clamav.cfg
+++ b/dspace/config/modules/clamav.cfg
@@ -11,7 +11,7 @@ service.host = 127.0.0.1
 service.port = 3310
 
 # Initial timeout value (in milliseconds) used when the socket is connecting
-socket.timeout = 5000
+socket.timeout = 120000
 
 # Flag indicating whether a scan should stop when the first infected bitstream
 # is detected within an item. Normally a complete scan is desired, so default


### PR DESCRIPTION
Addresses issue #390 
ClamAV takes a while to scan large files, and a timeout of 120 seconds ensures that any file < 1 GB won't timeout. 

It is also necessary to modify ClamAV daemon's config file `/etc/clamav/clamd.conf`

```
StreamMaxLength: 2000M
maxFileSize: 2000M
maxScanSize: 2000M
```

These high settings are needed for certain MOV and MP4s which need limits 10-20X the size of the file.
