### PR TITLE
Increased RSS feed item count to 10

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1424,7 +1424,7 @@ plugin.named.org.dspace.content.license.LicenseArgumentFormatter = \
 # (This setting is not used by XMLUI, as you enable feeds in your theme)
 webui.feed.enable = true
 # number of DSpace items per feed (the most recent submissions)
-webui.feed.items = 4
+webui.feed.items = 10
 # maximum number of feeds in memory cache
 # value of 0 will disable caching
 webui.feed.cache.size = 100


### PR DESCRIPTION
Since the dspace.cfg is manually diffed on deployment, this change might need to be noted somewhere.
Addresses issue #383
