### PR TITLE
Customization for Patents Collection - Facet and Search Filter

### DIFF
--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -52,8 +52,8 @@
                <entry key="10919/51287" value-ref="etdConfiguration"/>
                <entry key="10919/18725" value-ref="etdConfiguration"/>
                <entry key="10919/18726" value-ref="etdConfiguration"/>
-               <entry key="10919/52943" value-ref="patentConfiguration"/>
-               <entry key="10919/52944" value-ref="patentConfiguration"/>
+               <entry key="10919/72294" value-ref="patentConfiguration"/>
+               <entry key="10919/72295" value-ref="patentConfiguration"/>
             </map>
         </property>
         <property name="toIgnoreMetadataFields">
@@ -413,7 +413,6 @@
         <!-- When true a "did you mean" example will be displayed, value can be true or false -->
         <property name="spellCheckEnabled" value="true"/>
     </bean>
-  <!-- ANUSHA ADDED START-->
 <bean id="patentConfiguration" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
@@ -513,7 +512,6 @@
         <!-- When true a "did you mean" example will be displayed, value can be true or false -->
         <property name="spellCheckEnabled" value="true"/>   
     </bean>
-    <!-- ANUSHA ADDED END-->
     <!--TagCloud configuration bean for homepage discovery configuration-->
     <bean id="homepageTagCloudFacetConfiguration" class="org.dspace.discovery.configuration.TagCloudFacetConfiguration">
         <!-- Actual configuration of the tagcloud (colors, sorting, etc.) -->

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -52,6 +52,8 @@
                <entry key="10919/51287" value-ref="etdConfiguration"/>
                <entry key="10919/18725" value-ref="etdConfiguration"/>
                <entry key="10919/18726" value-ref="etdConfiguration"/>
+               <entry key="10919/52943" value-ref="patentConfiguration"/>
+               <entry key="10919/52944" value-ref="patentConfiguration"/>
             </map>
         </property>
         <property name="toIgnoreMetadataFields">
@@ -411,7 +413,107 @@
         <!-- When true a "did you mean" example will be displayed, value can be true or false -->
         <property name="spellCheckEnabled" value="true"/>
     </bean>
-
+  <!-- ANUSHA ADDED START-->
+<bean id="patentConfiguration" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+        <!--Which sidebar facets are to be displayed-->
+        <property name="sidebarFacets">
+            <list>
+                <ref bean="searchFilterPatentType"/>
+                <ref bean="searchFilterInventor"/>
+                <ref bean="searchFilterAssignee"/>
+                <ref bean="searchFilterPublicationDate"/>              
+            </list>
+        </property> 
+        <!--The search filters which can be used on the discovery search page-->
+        <property name="searchFilters">
+            <list>
+                <ref bean="searchFilterTitle" />
+                <ref bean="searchFilterAssignee"/>
+                <ref bean="searchFilterInventor"/>       
+                <ref bean="searchFilterApplicationNumber"/>
+                <ref bean="searchFilterPatentNumber"/>
+                <ref bean="searchFilterFilingDate"/>
+                <ref bean="searchFilterPublicationDate"/>
+                <ref bean="searchFilterAbstract" />
+                <ref bean="searchFilterUSClassPrimary"/>
+                <ref bean="searchFilterUSClassOthers"/>
+                <ref bean="searchFilterCPCClass"/>
+                <ref bean="searchFilterPatentType"/>  
+                             
+            </list>
+        </property> 
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <property name="defaultSortOrder" value="desc"/>
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortTitle" />
+                        <ref bean="sortDateIssued" />
+                    </list>
+                </property>
+            </bean>
+        </property>   
+         <property name="recentSubmissionConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
+                <property name="metadataSortField" value="dc.date.accessioned" />
+                <property name="type" value="date"/>
+                <property name="max" value="20"/>
+                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
+                <property name="useAsHomePage" value="false"/>
+            </bean>
+        </property>
+        <!--Default result per page  -->
+        <property name="defaultRpp" value="10" />
+        <property name="hitHighlightingConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
+                <property name="metadataFields">
+                    <list>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="dc.title"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="dc.contributor.author"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="dc.description.abstract"/>
+                            <property name="maxSize" value="250"/>
+                            <property name="snippets" value="2"/>
+                        </bean>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="fulltext"/>
+                            <property name="maxSize" value="250"/>
+                            <property name="snippets" value="2"/>
+                        </bean>
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="moreLikeThisConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoveryMoreLikeThisConfiguration">
+                <!--When altering this list also alter the "xmlui.Discovery.RelatedItems.help" key as it describes
+                the metadata fields below-->
+                <property name="similarityMetadataFields">
+                    <list>
+                        <value>dc.title</value>
+                        <value>dc.contributor.author</value>
+                        <value>dc.creator</value>
+                        <value>dc.subject</value>
+                    </list>
+                </property>
+                <!--The minimum number of matching terms across the metadata fields above before an item is found as related -->
+                <property name="minTermFrequency" value="5"/>
+                <!--The maximum number of related items displayed-->
+                <property name="max" value="3"/>
+                <!--The minimum word length below which words will be ignored-->
+                <property name="minWordLength" value="5"/>
+            </bean>
+        </property>
+        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
+        <property name="spellCheckEnabled" value="true"/>   
+    </bean>
+    <!-- ANUSHA ADDED END-->
     <!--TagCloud configuration bean for homepage discovery configuration-->
     <bean id="homepageTagCloudFacetConfiguration" class="org.dspace.discovery.configuration.TagCloudFacetConfiguration">
         <!-- Actual configuration of the tagcloud (colors, sorting, etc.) -->
@@ -419,7 +521,7 @@
         <!-- List of tagclouds to appear, one for every search filter, one after the other -->
         <property name="tagCloudFacets">
             <list>
-                <ref bean="searchFilterSubject" />
+                <ref bean="searchFilterSubject" />                
             </list>
         </property>
     </bean>
@@ -598,6 +700,56 @@
             </list>
         </property>
     </bean>
+    
+    <bean id="searchFilterApplicationNumber" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="applicationNumber"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.identifier.applicationnumber</value>
+            </list>
+        </property>
+    </bean>
+    
+    <bean id="searchFilterPatentNumber" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="patentNumber"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.identifier.patentnumber</value>
+            </list>
+        </property>
+    </bean>    
+      <bean id="searchFilterFilingDate" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+         <property name="indexFieldName" value="filingDate"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.date.filed</value>
+            </list>
+        </property>
+    </bean>
+    <bean id="searchFilterUSClassPrimary" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+         <property name="indexFieldName" value="usClassPrimary"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.subject.uspc</value>
+            </list>
+        </property>
+    </bean>
+    <bean id="searchFilterUSClassOthers" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+         <property name="indexFieldName" value="usClassOther"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.subject.uspcother</value>
+            </list>
+        </property>
+    </bean>
+     <bean id="searchFilterCPCClass" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+         <property name="indexFieldName" value="cpcClass"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.subject.cpc</value>
+            </list>
+        </property>
+    </bean>
 
     <!--Search filter facet configuration beans-->
     <bean id="searchFilterAdvisor" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
@@ -611,7 +763,7 @@
         </property>
         <property name="sortOrder" value="COUNT"/>
         <property name="facetLimit" value="5"/>
-    </bean>
+    </bean> 
     
     <bean id="searchFilterAuthor" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
         <property name="indexFieldName" value="author"/>
@@ -685,7 +837,48 @@
         <property name="sortOrder" value="COUNT"/>
         <property name="facetLimit" value="5"/>
     </bean>
-
+    
+    <bean id="searchFilterPatentType" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="patenttype"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.type.patenttype</value>
+            </list>
+        </property>
+        <property name="sortOrder" value="COUNT"/>
+        <property name="facetLimit" value="5"/>
+    </bean>
+	<bean id="searchFilterInventor" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="inventor"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.contributor.inventor</value>                
+            </list>
+        </property>
+        <property name="sortOrder" value="COUNT"/>
+        <property name="facetLimit" value="5"/>
+    </bean>
+    
+        <bean id="searchFilterAssignee" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="assignee"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.contributor.assignee</value>                
+            </list>
+        </property>
+        <property name="sortOrder" value="COUNT"/>
+        <property name="facetLimit" value="5"/>
+    </bean>
+     <bean id="searchFilterPublicationDate" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="publicationDate"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.date.issued</value>
+            </list>
+        </property>
+        <property name="type" value="date"/>
+        <property name="sortOrder" value="VALUE"/>
+    </bean>
     <!--Sort properties-->
     <bean id="sortTitle" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">
         <property name="metadataField" value="dc.title"/>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -290,7 +290,7 @@
     </xsl:template>
 
     <xsl:template name="itemSummaryView-DIM-authors">
-        <xsl:if test="dim:field[@element='contributor'][@qualifier='author' and descendant::text()] or dim:field[@element='creator' and descendant::text()] or dim:field[@element='contributor' and descendant::text()]">
+        <xsl:if test="dim:field[@element='contributor'][@qualifier='author' and descendant::text()] or dim:field[@element='creator' and descendant::text()] or dim:field[@element='contributor' and descendant::text()] or dim:field[@element='contributor'][@qualifier='inventor' and descendant::text()] ">
             <div class="simple-item-view-authors item-page-field-wrapper table">
                 <h5><i18n:text>xmlui.dri2xhtml.METS-1.0.item-author</i18n:text></h5>
                 <xsl:choose>
@@ -306,6 +306,11 @@
                     </xsl:when>
                     <xsl:when test="dim:field[@element='contributor']">
                         <xsl:for-each select="dim:field[@element='contributor']">
+                            <xsl:call-template name="itemSummaryView-DIM-authors-entry" />
+                        </xsl:for-each>
+                    </xsl:when>
+                    <xsl:when test="dim:field[@element='contributor'][@qualifier='inventor']">
+                        <xsl:for-each select="dim:field[@element='contributor'][@qualifier='inventor']">
                             <xsl:call-template name="itemSummaryView-DIM-authors-entry" />
                         </xsl:for-each>
                     </xsl:when>
@@ -363,7 +368,7 @@
     
     <xsl:template name="itemSummaryView-DIM-date">
         <xsl:if test="dim:field[@element='date' and @qualifier='issued' and descendant::text()]">
-            <div class="simple-item-view-date word-break item-page-field-wrapper table">
+            <div class="simple-item-view-date word-break item-page-field-wrapper table">             
                 <h5>
                     <i18n:text>xmlui.dri2xhtml.METS-1.0.item-date</i18n:text>
                 </h5>
@@ -372,7 +377,7 @@
                     <xsl:if test="count(following-sibling::dim:field[@element='date' and @qualifier='issued']) != 0">
                         <br/>
                     </xsl:if>
-                </xsl:for-each>
+                </xsl:for-each>               
             </div>
         </xsl:if>
     </xsl:template>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/discovery/discovery.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/discovery/discovery.xsl
@@ -242,6 +242,26 @@
                                     </xsl:if>
                                 </xsl:for-each>
                             </xsl:when>
+                            <xsl:when test="dri:list[@n=(concat($handle, ':dc.contributor.inventor'))]">
+                                <xsl:for-each select="dri:list[@n=(concat($handle, ':dc.contributor.inventor'))]/dri:item">
+                                    <xsl:variable name="inventor">
+                                        <xsl:apply-templates select="."/>
+                                    </xsl:variable>
+                                    <span>
+                                        <!--Check authority in the mets document-->
+                                        <xsl:if test="$metsDoc/mets:METS/mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim/dim:field[@element='contributor' and @qualifier='inventor']/@authority">
+                                            <xsl:attribute name="class">
+                                                <xsl:text>ds-dc_contributor_author-authority</xsl:text>
+                                            </xsl:attribute>
+                                        </xsl:if>
+                                        <xsl:apply-templates select="."/>
+                                    </span>
+
+                                    <xsl:if test="count(following-sibling::dri:item) != 0">
+                                        <xsl:text>; </xsl:text>
+                                    </xsl:if>
+                                </xsl:for-each>
+                            </xsl:when>
                             <xsl:otherwise>
                                 <i18n:text>xmlui.dri2xhtml.METS-1.0.no-author</i18n:text>
                             </xsl:otherwise>

--- a/dspace/modules/xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
@@ -48,6 +48,12 @@
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_etdlevel">Thesis Degree Level</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Department</message>
     <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.relation.ispartofseries_filter">Series</message>
+   	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_patenttype">Patent Type</message>
+   	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_inventor">Inventor</message>
+   	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_assignee">Assignee</message>
+   	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_publicationDate">Publication Date</message>
+    
+    
 
     <!-- Site Leve Recently Added Content -->
     <message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">Recently Added</message>
@@ -104,6 +110,16 @@
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.coverage">Coverage</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.trnumber">Technical Report No.</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.committeemember">Committee Member</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.assignee">Assignee</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.inventor">Inventor</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.applicationNumber">Application Number</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.patentNumber">Patent Number</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.filingDate">Filing Date</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.publicationDate">Publication Date</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.usClassPrimary">Primary/U.S. Class</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.usClassOther">Other/U.S. Class</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.cpcClass">CPC Class</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.patenttype">Patent Type</message>
 
     <message key="xmlui.dri2xhtml.structural.pagination-info.nototal">Now showing items {0}-{1}</message>
 
@@ -125,7 +141,7 @@
     <message key="xmlui.Discovery.AbstractSearch.type_etdlevel">Filter by: Thesis Degree Level</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.etdlevel">Thesis Degree Level</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.etdlevel_filter">Thesis Degree Level</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued.year">Date Issued</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued.year">Date Issued</message>    
 
 
     <message key="xmlui.Discovery.AbstractSearch.startswith">Starts with</message>

--- a/dspace/modules/xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml
@@ -141,7 +141,11 @@
     <message key="xmlui.Discovery.AbstractSearch.type_etdlevel">Filter by: Thesis Degree Level</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.etdlevel">Thesis Degree Level</message>
     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.etdlevel_filter">Thesis Degree Level</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued.year">Date Issued</message>    
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued.year">Date Issued</message>  
+    <message key="xmlui.Discovery.AbstractSearch.type_assignee">Filter by: Assignee</message>
+    <message key="xmlui.Discovery.AbstractSearch.type_inventor">Filter by: Inventor</message>
+    <message key="xmlui.Discovery.AbstractSearch.type_patenttype">Filter by: Patent Type</message>
+         
 
 
     <message key="xmlui.Discovery.AbstractSearch.startswith">Starts with</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2231,7 +2231,17 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-date">Date</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Publisher</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Subject</message>
-        <message key="xmlui.dri2xhtml.METS-1.0.item-trnumber">TR number</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-trnumber">TR number</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-inventor">Inventor</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-datefiled">Filing Date</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-dateissued">Publication Date</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-applicationnumber">Application Number</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-patentnumber">Patent Number</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-uspc">Primary/U.S. Class</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-uspcother">Other/U.S. Class</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-cpc">CPC Class</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-patenttype">Patent Type</message>
+    
 
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Files in this item</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Files</message>


### PR DESCRIPTION
Resolved a subset of issue #374: Customized the facets and the search filter for the patent collections.

Modified the discovery file to add a new configuration for patent handles and added properties in the message.xml that defines the display title. The SimpleSearch property keys are for the search filter and the AdvancedSearch property keys are for facets.
