### PR TITLE
RSS author display changes

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1460,18 +1460,19 @@ webui.feed.item.date = dc.date.issued
 # e.g.   "metadata.dc.title"
 #        "metadata.dc.contributor.author"
 #        "metadata.dc.date.issued"
-webui.feed.item.description = dc.title, dc.contributor.author, \
-                                                          dc.contributor.editor, dc.description.abstract, \
-                                                          dc.description
+webui.feed.item.description =  dc.description.abstract, dc.description
 # name of field to use for authors (Atom only) - repeatable
-webui.feed.item.author = dc.contributor.author
+#webui.feed.item.author = dc.contributor.author
+
+# Boolean option for Atom - don't show dc.creator since author is already present
+webui.feed.atom.dc.author.show = false
 
 # Customize the extra namespaced DC elements added to the item (RSS) or entry
 # (Atom) element.  These let you include individual metadata values in a
 # structured format for easy extraction by the recipient, instead of (or in
 # addition to) appending these values to the Description field.
 ## dc:creator value(s)
-#webui.feed.item.dc.creator = dc.contributor.author
+webui.feed.item.dc.creator = dc.contributor.author
 ## dc:date value (may be contradicted by webui.feed.item.date)
 #webui.feed.item.dc.date = dc.date.issued
 ## dc:description (e.g. for a distinct field that is ONLY the abstract)

--- a/dspace/modules/additions/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -316,7 +316,8 @@ public class SyndicationFeed
                     dcDescriptionField != null)
                 {
                     DCModule dc = new DCModuleImpl();
-                    if (dcCreatorField != null)
+                    if (dcCreatorField != null &&
+                            ConfigurationManager.getBooleanProperty("webui.feed.atom.dc.author.show"))
                     {
                         Metadatum dcAuthors[] = item.getMetadataByMetadataString(dcCreatorField);
                         if (dcAuthors.length > 0)


### PR DESCRIPTION
- For all 3 RSS feed types: `description` tag only contains abstract if present, else description if present, else doesn't exist
- `dc:creator` tag is used for RSS 1.0 and 2.0,  `author` used for Atom
-  Made option to suppress showing `dc.creator` for Atom, and enabled that supression

Note that most RSS clients don't display author or dc.creator tags by default.
