### PR TITLE
Individual download stats

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -529,6 +529,7 @@
         <div>
             <xsl:variable name="solr-search-url" select="confman:getProperty('solr-statistics', 'server')"/>
             <i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-numDownloads</i18n:text>
+            <xsl:text>: </xsl:text>
             <xsl:value-of select="document(concat($solr-search-url, '/select?q=id%3A', substring($id, 6), '+AND+type%3A0&amp;rows=0'))/response/result/@numFound"/>
         </div>
 
@@ -727,6 +728,14 @@
                             <xsl:value-of select="util:shortenString(mets:FLocat[@LOCTYPE='URL']/@xlink:label, 30, 5)"/>
                         </dd>
                 </xsl:if>
+                    <dt>
+                        <i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-numDownloads</i18n:text>
+                        <xsl:text>: </xsl:text>
+                    </dt>
+                    <dd>
+                        <xsl:variable name="solr-search-url" select="confman:getProperty('solr-statistics', 'server')"/>
+                        <xsl:value-of select="document(concat($solr-search-url, '/select?q=id%3A', substring(@ID, 6), '+AND+type%3A0&amp;rows=0'))/response/result/@numFound"/>
+                    </dd>
                 </dl>
             </div>
 

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -409,7 +409,6 @@
                     <h5>
                         <i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-viewOpen</i18n:text>
                     </h5>
-
                     <xsl:variable name="label-1">
                             <xsl:choose>
                                 <xsl:when test="confman:getProperty('mirage2.item-view.bitstream.href.label.1')">
@@ -441,6 +440,7 @@
                             <xsl:with-param name="title" select="mets:FLocat[@LOCTYPE='URL']/@xlink:title" />
                             <xsl:with-param name="label" select="mets:FLocat[@LOCTYPE='URL']/@xlink:label" />
                             <xsl:with-param name="size" select="@SIZE" />
+                            <xsl:with-param name="id" select="@ID" />
                         </xsl:call-template>
                     </xsl:for-each>
                 </div>
@@ -460,6 +460,7 @@
         <xsl:param name="title" />
         <xsl:param name="label" />
         <xsl:param name="size" />
+        <xsl:param name="id" />
         <!-- display of long file name -->
 		<div class="filename-word-break">
             <a>
@@ -525,6 +526,12 @@
                 <xsl:text>)</xsl:text>
             </a>
         </div>
+        <div>
+            <xsl:variable name="solr-search-url" select="confman:getProperty('solr-statistics', 'server')"/>
+            <i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-numDownloads</i18n:text>
+            <xsl:value-of select="document(concat($solr-search-url, '/select?q=id%3A', substring($id, 6), '+AND+type%3A0&amp;rows=0'))/response/result/@numFound"/>
+        </div>
+
     </xsl:template>
 
     <xsl:template match="dim:dim" mode="itemDetailView-DIM">

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2243,7 +2243,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">View/<wbr/>Open</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-access-rights">Read access available for</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">There are no files associated with this item.</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-files-numDownloads">Downloads: </message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-files-numDownloads">Downloads</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2243,6 +2243,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">View/<wbr/>Open</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-access-rights">Read access available for</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">There are no files associated with this item.</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-files-numDownloads">Downloads: </message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>


### PR DESCRIPTION
Download count is now present for each file listed in simple item view. Addresses issue #317.

I tested with various files and submissions with multiple files. Download count increases as expected.

<img width="500" alt="screen shot 2016-11-04 at 11 50 43 am" src="https://cloud.githubusercontent.com/assets/7339589/20012320/253e6ed2-a285-11e6-87b6-4a9f7c2d8cbf.png">
