### PR TITLE
Reconfigures RSS and Atom syndication feeds in dspace.cfg to show the…

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1464,7 +1464,7 @@ webui.feed.item.date = dc.date.issued
 # e.g.   "metadata.dc.title"
 #        "metadata.dc.contributor.author"
 #        "metadata.dc.date.issued"
-webui.feed.item.description =  dc.description.abstract, dc.description
+webui.feed.item.description =  dc.contributor.author, dc.contributor.editor
 # name of field to use for authors (Atom only) - repeatable
 #webui.feed.item.author = dc.contributor.author
 
@@ -1476,11 +1476,11 @@ webui.feed.atom.dc.author.show = false
 # structured format for easy extraction by the recipient, instead of (or in
 # addition to) appending these values to the Description field.
 ## dc:creator value(s)
-webui.feed.item.dc.creator = dc.contributor.author
+webui.feed.item.dc.creator = dc.contributor.*
 ## dc:date value (may be contradicted by webui.feed.item.date)
 #webui.feed.item.dc.date = dc.date.issued
 ## dc:description (e.g. for a distinct field that is ONLY the abstract)
-#webui.feed.item.dc.description = dc.description.abstract
+webui.feed.item.dc.description = dc.description.abstract
 
 # Customize the image icon included with the site-wide feeds:
 # Must be an absolute URL, e.g.


### PR DESCRIPTION
… author in the description element. Addresses closed issue #424. Authors now show up in the source data for all syndication feeds, but abstracts will not appear in the Atom feed. 