### PR TITLE
Custom item view for Patents

### DIFF
--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -52,8 +52,8 @@
                <entry key="10919/51287" value-ref="etdConfiguration"/>
                <entry key="10919/18725" value-ref="etdConfiguration"/>
                <entry key="10919/18726" value-ref="etdConfiguration"/>
-               <entry key="10919/72294" value-ref="patentConfiguration"/>
-               <entry key="10919/72295" value-ref="patentConfiguration"/>
+               <entry key="10919/52943" value-ref="patentConfiguration"/>
+               <entry key="10919/52944" value-ref="patentConfiguration"/>
             </map>
         </property>
         <property name="toIgnoreMetadataFields">

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -52,8 +52,8 @@
                <entry key="10919/51287" value-ref="etdConfiguration"/>
                <entry key="10919/18725" value-ref="etdConfiguration"/>
                <entry key="10919/18726" value-ref="etdConfiguration"/>
-               <entry key="10919/52943" value-ref="patentConfiguration"/>
-               <entry key="10919/52944" value-ref="patentConfiguration"/>
+               <entry key="10919/72294" value-ref="patentConfiguration"/>
+               <entry key="10919/72295" value-ref="patentConfiguration"/>
             </map>
         </property>
         <property name="toIgnoreMetadataFields">

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -307,8 +307,8 @@
                             <xsl:call-template name="itemSummaryView-DIM-authors-entry" />
                         </xsl:for-each>
                     </xsl:when>
-                    <xsl:when test="dim:field[@element='contributor']">
-                        <xsl:for-each select="dim:field[@element='contributor']">
+                    <xsl:when test="dim:field[@element='contributor'][@qualifier='author']">
+                        <xsl:for-each select="dim:field[@element='contributor'][@qualifier='author']">
                             <xsl:call-template name="itemSummaryView-DIM-authors-entry" />
                         </xsl:for-each>
                     </xsl:when>
@@ -372,27 +372,28 @@
 <xsl:template name="itemSummaryView-DIM-date">
 <div class="simple-item-view-date word-break item-page-field-wrapper table">
 <xsl:choose>
-        <xsl:when test="contains($document//dri:referenceSet[@id='aspect.artifactbrowser.ItemViewer.referenceSet.collection-viewer']/dri:reference[@type='DSpace Item']/dri:referenceSet[@type='itemPageSummaryList']/dri:reference/@url,'10919/52944/')">
+        <!-- Note: Patent collection handle is 10919/72295 on full database -->
+        <xsl:when test="contains($document//dri:referenceSet[@id='aspect.artifactbrowser.ItemViewer.referenceSet.collection-viewer']/dri:reference[@type='DSpace Item']/dri:referenceSet[@type='itemPageSummaryList']/dri:reference/@url,'/handle/10919/52980/')">
         <xsl:if test="dim:field[@element='date' and @qualifier='issued' and descendant::text()]">
-                 <h5>
-                    <i18n:text>xmlui.dri2xhtml.METS-1.0.item-datefiled</i18n:text>
-                </h5>
-                <xsl:for-each select="dim:field[@element='date' and @qualifier='filed']">
+            <h5>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-datefiled</i18n:text>
+            </h5>
+            <xsl:for-each select="dim:field[@element='date' and @qualifier='filed']">
                     <xsl:copy-of select="substring(./node(),1,10)"/>
                     <xsl:if test="count(following-sibling::dim:field[@element='date' and @qualifier='filed']) != 0">
                         <br/>
                     </xsl:if>
-                </xsl:for-each>
+            </xsl:for-each>
 
-                <h5>
-                    <i18n:text>xmlui.dri2xhtml.METS-1.0.item-dateissued</i18n:text>
-                </h5>
-                <xsl:for-each select="dim:field[@element='date' and @qualifier='issued']">
-                    <xsl:copy-of select="substring(./node(),1,10)"/>
-                    <xsl:if test="count(following-sibling::dim:field[@element='date' and @qualifier='issued']) != 0">
-                        <br/>
-                    </xsl:if>
-                </xsl:for-each>
+            <h5>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-dateissued</i18n:text>
+            </h5>
+            <xsl:for-each select="dim:field[@element='date' and @qualifier='issued']">
+                <xsl:copy-of select="substring(./node(),1,10)"/>
+                <xsl:if test="count(following-sibling::dim:field[@element='date' and @qualifier='issued']) != 0">
+                    <br/>
+                </xsl:if>
+            </xsl:for-each>
         </xsl:if>
         </xsl:when>
         <xsl:otherwise>
@@ -411,15 +412,102 @@
 </xsl:template>
 
 <xsl:template name="itemSummaryView-DIM-Patent-Info">
-<xsl:if test="contains($document//dri:referenceSet[@id='aspect.artifactbrowser.ItemViewer.referenceSet.collection-viewer']/dri:reference[@type='DSpace Item']/dri:referenceSet[@type='itemPageSummaryList']/dri:reference/@url,'10919/52944/')">
-<div class="simple-item-view-show-full item-page-field-wrapper table">
-<h5>
+    <!-- Note: Patent collection handle is 10919/72295 on full database -->
+    <xsl:if test="contains($document//dri:referenceSet[@id='aspect.artifactbrowser.ItemViewer.referenceSet.collection-viewer']/dri:reference[@type='DSpace Item']/dri:referenceSet[@type='itemPageSummaryList']/dri:reference/@url,'/handle/10919/52980/')">
+        <div class="simple-item-view-show-full item-page-field-wrapper table">
+            <h5>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-assignee</i18n:text>
+            </h5>
+            <xsl:for-each select="dim:field[@element='contributor' and @qualifier='assignee']">
+                <div>
+                    <xsl:copy-of select="./node()"/>
+                </div>
+            </xsl:for-each>
+        </div>
+        <div class="simple-item-view-show-full item-page-field-wrapper table">
+            <h5>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-inventor</i18n:text>
+            </h5>
+            <xsl:for-each select="dim:field[@element='contributor' and @qualifier='inventor']">
+                <div>
+                    <xsl:copy-of select="./node()"/>
+                </div>
+            </xsl:for-each>
+        </div>
+        <div class="simple-item-view-show-full item-page-field-wrapper table">
+            <h5>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-applicationnumber</i18n:text>
+            </h5>
+            <xsl:for-each select="dim:field[@element='identifier' and @qualifier='applicationnumber']">
+                <div>
+                    <xsl:copy-of select="./node()"/>
+                </div>
+            </xsl:for-each>
+        </div>
+        <div class="simple-item-view-show-full item-page-field-wrapper table">
+            <h5>
                 <i18n:text>xmlui.dri2xhtml.METS-1.0.item-patentnumber</i18n:text>
-</h5>
-<xsl:for-each select="dim:field[@element='identifier' and @qualifier='patentnumber']">
-</xsl:for-each>
-</div>
-</xsl:if>		
+            </h5>
+            <xsl:for-each select="dim:field[@element='identifier' and @qualifier='patentnumber']">
+                <div>
+                    <xsl:copy-of select="./node()"/>
+                </div>
+            </xsl:for-each>
+        </div>
+        <div class="simple-item-view-show-full item-page-field-wrapper table">
+            <h5>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-url</i18n:text>
+            </h5>
+            <xsl:for-each select="dim:field[@element='identifier' and @qualifier='url']">
+                <div>
+                    <a>
+                        <xsl:attribute name="href"><xsl:value-of select="./node()"/></xsl:attribute>
+                        <xsl:copy-of select="./node()"/>
+                    </a>
+                </div>
+            </xsl:for-each>
+        </div>
+        <div class="simple-item-view-show-full item-page-field-wrapper table">
+            <h5>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-uspc</i18n:text>
+            </h5>
+            <xsl:for-each select="dim:field[@element='subject' and @qualifier='uspc']">
+                <div>
+                    <xsl:copy-of select="./node()"/>
+                </div>
+            </xsl:for-each>
+        </div>
+        <div class="simple-item-view-show-full item-page-field-wrapper table">
+            <h5>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-uspcother</i18n:text>
+            </h5>
+            <xsl:for-each select="dim:field[@element='subject' and @qualifier='uspcother']">
+                <div>
+                    <xsl:copy-of select="./node()"/>
+                </div>
+            </xsl:for-each>
+        </div>
+        <div class="simple-item-view-show-full item-page-field-wrapper table">
+            <h5>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-cpc</i18n:text>
+            </h5>
+            <xsl:for-each select="dim:field[@element='subject' and @qualifier='cpc']">
+                <div>
+                    <xsl:copy-of select="./node()"/>
+                </div>
+            </xsl:for-each>
+        </div>
+        <div class="simple-item-view-show-full item-page-field-wrapper table">
+            <h5>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-patenttype</i18n:text>
+            </h5>
+            <xsl:for-each select="dim:field[@element='type' and @qualifier='patenttype']">
+                <div>
+                    <xsl:copy-of select="./node()"/>
+                </div>
+            </xsl:for-each>
+        </div>
+    </xsl:if>
 </xsl:template>
 
     <xsl:template name="itemSummaryView-show-full">

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -183,6 +183,7 @@
                 </div>
                 <div class="col-sm-8">
                     <xsl:call-template name="itemSummaryView-DIM-abstract"/>
+                    <xsl:call-template name="itemSummaryView-DIM-Patent-Info"/>
                     <xsl:call-template name="itemSummaryView-DIM-URI"/>
                     <xsl:call-template name="itemSummaryView-collections"/>
                 </div>
@@ -368,9 +369,33 @@
        </xsl:if>
     </xsl:template>
     
-    <xsl:template name="itemSummaryView-DIM-date">
+<xsl:template name="itemSummaryView-DIM-date">
+<div class="simple-item-view-date word-break item-page-field-wrapper table">
+<xsl:choose>
+        <xsl:when test="contains($document//dri:referenceSet[@id='aspect.artifactbrowser.ItemViewer.referenceSet.collection-viewer']/dri:reference[@type='DSpace Item']/dri:referenceSet[@type='itemPageSummaryList']/dri:reference/@url,'10919/52944/')">
         <xsl:if test="dim:field[@element='date' and @qualifier='issued' and descendant::text()]">
-            <div class="simple-item-view-date word-break item-page-field-wrapper table">             
+                 <h5>
+                    <i18n:text>xmlui.dri2xhtml.METS-1.0.item-datefiled</i18n:text>
+                </h5>
+                <xsl:for-each select="dim:field[@element='date' and @qualifier='filed']">
+                    <xsl:copy-of select="substring(./node(),1,10)"/>
+                    <xsl:if test="count(following-sibling::dim:field[@element='date' and @qualifier='filed']) != 0">
+                        <br/>
+                    </xsl:if>
+                </xsl:for-each>
+
+                <h5>
+                    <i18n:text>xmlui.dri2xhtml.METS-1.0.item-dateissued</i18n:text>
+                </h5>
+                <xsl:for-each select="dim:field[@element='date' and @qualifier='issued']">
+                    <xsl:copy-of select="substring(./node(),1,10)"/>
+                    <xsl:if test="count(following-sibling::dim:field[@element='date' and @qualifier='issued']) != 0">
+                        <br/>
+                    </xsl:if>
+                </xsl:for-each>
+        </xsl:if>
+        </xsl:when>
+        <xsl:otherwise>
                 <h5>
                     <i18n:text>xmlui.dri2xhtml.METS-1.0.item-date</i18n:text>
                 </h5>
@@ -379,10 +404,23 @@
                     <xsl:if test="count(following-sibling::dim:field[@element='date' and @qualifier='issued']) != 0">
                         <br/>
                     </xsl:if>
-                </xsl:for-each>               
-            </div>
-        </xsl:if>
-    </xsl:template>
+                </xsl:for-each>
+        </xsl:otherwise>
+</xsl:choose>
+</div>
+</xsl:template>
+
+<xsl:template name="itemSummaryView-DIM-Patent-Info">
+<xsl:if test="contains($document//dri:referenceSet[@id='aspect.artifactbrowser.ItemViewer.referenceSet.collection-viewer']/dri:reference[@type='DSpace Item']/dri:referenceSet[@type='itemPageSummaryList']/dri:reference/@url,'10919/52944/')">
+<div class="simple-item-view-show-full item-page-field-wrapper table">
+<h5>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-patentnumber</i18n:text>
+</h5>
+<xsl:for-each select="dim:field[@element='identifier' and @qualifier='patentnumber']">
+</xsl:for-each>
+</div>
+</xsl:if>		
+</xsl:template>
 
     <xsl:template name="itemSummaryView-show-full">
         <div class="simple-item-view-show-full item-page-field-wrapper table">

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -295,8 +295,18 @@
     <xsl:template name="itemSummaryView-DIM-authors">
         <xsl:if test="dim:field[@element='contributor'][@qualifier='author' and descendant::text()] or dim:field[@element='creator' and descendant::text()] or dim:field[@element='contributor' and descendant::text()] or dim:field[@element='contributor'][@qualifier='inventor' and descendant::text()] ">
             <div class="simple-item-view-authors item-page-field-wrapper table">
-                <h5><i18n:text>xmlui.dri2xhtml.METS-1.0.item-author</i18n:text></h5>
-                <xsl:choose>
+				<h5>
+					<xsl:choose>
+						<xsl:when test="dim:field[@element='contributor'][@qualifier='inventor']">
+							<i18n:text>xmlui.dri2xhtml.METS-1.0.item-inventor</i18n:text>
+						</xsl:when>
+						<xsl:otherwise>
+							<i18n:text>xmlui.dri2xhtml.METS-1.0.item-author</i18n:text>
+						</xsl:otherwise>
+				
+					</xsl:choose>
+				</h5>
+				<xsl:choose>
                     <xsl:when test="dim:field[@element='contributor'][@qualifier='author']">
                         <xsl:for-each select="dim:field[@element='contributor'][@qualifier='author']">
                             <xsl:call-template name="itemSummaryView-DIM-authors-entry" />
@@ -413,16 +423,6 @@
 <xsl:template name="itemSummaryView-DIM-Patent-Info">
     <!-- Note: Patent collection handle is 10919/72295 on full database -->
     <xsl:if test="contains($document//dri:referenceSet[@id='aspect.artifactbrowser.ItemViewer.referenceSet.collection-viewer']/dri:reference[@type='DSpace Item']/dri:referenceSet[@type='itemPageSummaryList']/dri:reference/@url,'/handle/10919/72295/')">
-        <div class="simple-item-view-show-full item-page-field-wrapper table">
-            <h5>
-                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-inventor</i18n:text>
-            </h5>
-            <xsl:for-each select="dim:field[@element='contributor' and @qualifier='inventor']">
-                <div>
-                    <xsl:copy-of select="./node()"/>
-                </div>
-            </xsl:for-each>
-        </div>
         <div class="simple-item-view-show-full item-page-field-wrapper table">
             <h5>
                 <i18n:text>xmlui.dri2xhtml.METS-1.0.item-assignee</i18n:text>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -376,16 +376,6 @@
         <xsl:when test="contains($document//dri:referenceSet[@id='aspect.artifactbrowser.ItemViewer.referenceSet.collection-viewer']/dri:reference[@type='DSpace Item']/dri:referenceSet[@type='itemPageSummaryList']/dri:reference/@url,'/handle/10919/72295/')">
         <xsl:if test="dim:field[@element='date' and @qualifier='issued' and descendant::text()]">
             <h5>
-                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-datefiled</i18n:text>
-            </h5>
-            <xsl:for-each select="dim:field[@element='date' and @qualifier='filed']">
-                    <xsl:copy-of select="substring(./node(),1,10)"/>
-                    <xsl:if test="count(following-sibling::dim:field[@element='date' and @qualifier='filed']) != 0">
-                        <br/>
-                    </xsl:if>
-            </xsl:for-each>
-
-            <h5>
                 <i18n:text>xmlui.dri2xhtml.METS-1.0.item-dateissued</i18n:text>
             </h5>
             <xsl:for-each select="dim:field[@element='date' and @qualifier='issued']">
@@ -393,6 +383,15 @@
                 <xsl:if test="count(following-sibling::dim:field[@element='date' and @qualifier='issued']) != 0">
                     <br/>
                 </xsl:if>
+            </xsl:for-each>
+            <h5>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-datefiled</i18n:text>
+            </h5>
+            <xsl:for-each select="dim:field[@element='date' and @qualifier='filed']">
+                    <xsl:copy-of select="substring(./node(),1,10)"/>
+                    <xsl:if test="count(following-sibling::dim:field[@element='date' and @qualifier='filed']) != 0">
+                        <br/>
+                    </xsl:if>
             </xsl:for-each>
         </xsl:if>
         </xsl:when>
@@ -416,16 +415,6 @@
     <xsl:if test="contains($document//dri:referenceSet[@id='aspect.artifactbrowser.ItemViewer.referenceSet.collection-viewer']/dri:reference[@type='DSpace Item']/dri:referenceSet[@type='itemPageSummaryList']/dri:reference/@url,'/handle/10919/72295/')">
         <div class="simple-item-view-show-full item-page-field-wrapper table">
             <h5>
-                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-assignee</i18n:text>
-            </h5>
-            <xsl:for-each select="dim:field[@element='contributor' and @qualifier='assignee']">
-                <div>
-                    <xsl:copy-of select="./node()"/>
-                </div>
-            </xsl:for-each>
-        </div>
-        <div class="simple-item-view-show-full item-page-field-wrapper table">
-            <h5>
                 <i18n:text>xmlui.dri2xhtml.METS-1.0.item-inventor</i18n:text>
             </h5>
             <xsl:for-each select="dim:field[@element='contributor' and @qualifier='inventor']">
@@ -436,9 +425,9 @@
         </div>
         <div class="simple-item-view-show-full item-page-field-wrapper table">
             <h5>
-                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-applicationnumber</i18n:text>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-assignee</i18n:text>
             </h5>
-            <xsl:for-each select="dim:field[@element='identifier' and @qualifier='applicationnumber']">
+            <xsl:for-each select="dim:field[@element='contributor' and @qualifier='assignee']">
                 <div>
                     <xsl:copy-of select="./node()"/>
                 </div>
@@ -449,6 +438,16 @@
                 <i18n:text>xmlui.dri2xhtml.METS-1.0.item-patentnumber</i18n:text>
             </h5>
             <xsl:for-each select="dim:field[@element='identifier' and @qualifier='patentnumber']">
+                <div>
+                    <xsl:copy-of select="./node()"/>
+                </div>
+            </xsl:for-each>
+        </div>
+        <div class="simple-item-view-show-full item-page-field-wrapper table">
+            <h5>
+                <i18n:text>xmlui.dri2xhtml.METS-1.0.item-applicationnumber</i18n:text>
+            </h5>
+            <xsl:for-each select="dim:field[@element='identifier' and @qualifier='applicationnumber']">
                 <div>
                     <xsl:copy-of select="./node()"/>
                 </div>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -373,7 +373,7 @@
 <div class="simple-item-view-date word-break item-page-field-wrapper table">
 <xsl:choose>
         <!-- Note: Patent collection handle is 10919/72295 on full database -->
-        <xsl:when test="contains($document//dri:referenceSet[@id='aspect.artifactbrowser.ItemViewer.referenceSet.collection-viewer']/dri:reference[@type='DSpace Item']/dri:referenceSet[@type='itemPageSummaryList']/dri:reference/@url,'/handle/10919/52980/')">
+        <xsl:when test="contains($document//dri:referenceSet[@id='aspect.artifactbrowser.ItemViewer.referenceSet.collection-viewer']/dri:reference[@type='DSpace Item']/dri:referenceSet[@type='itemPageSummaryList']/dri:reference/@url,'/handle/10919/72295/')">
         <xsl:if test="dim:field[@element='date' and @qualifier='issued' and descendant::text()]">
             <h5>
                 <i18n:text>xmlui.dri2xhtml.METS-1.0.item-datefiled</i18n:text>
@@ -413,7 +413,7 @@
 
 <xsl:template name="itemSummaryView-DIM-Patent-Info">
     <!-- Note: Patent collection handle is 10919/72295 on full database -->
-    <xsl:if test="contains($document//dri:referenceSet[@id='aspect.artifactbrowser.ItemViewer.referenceSet.collection-viewer']/dri:reference[@type='DSpace Item']/dri:referenceSet[@type='itemPageSummaryList']/dri:reference/@url,'/handle/10919/52980/')">
+    <xsl:if test="contains($document//dri:referenceSet[@id='aspect.artifactbrowser.ItemViewer.referenceSet.collection-viewer']/dri:reference[@type='DSpace Item']/dri:referenceSet[@type='itemPageSummaryList']/dri:reference/@url,'/handle/10919/72295/')">
         <div class="simple-item-view-show-full item-page-field-wrapper table">
             <h5>
                 <i18n:text>xmlui.dri2xhtml.METS-1.0.item-assignee</i18n:text>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2238,7 +2238,7 @@
     <message key="xmlui.dri2xhtml.METS-1.0.item-dateissued">Publication Date</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-applicationnumber">Application Number</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-patentnumber">Patent Number</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-url">URL</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-url">Source URL</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-uspc">Primary/U.S. Class</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-uspcother">Other/U.S. Class</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-cpc">CPC Class</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2232,11 +2232,13 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Publisher</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Subject</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-trnumber">TR number</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-assignee">Assignee</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-inventor">Inventor</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-datefiled">Filing Date</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dateissued">Publication Date</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-applicationnumber">Application Number</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-patentnumber">Patent Number</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-url">URL</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-uspc">Primary/U.S. Class</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-uspcother">Other/U.S. Class</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-cpc">CPC Class</message>


### PR DESCRIPTION
Custom fields for patents now show in the center column of simple item view. 
The item date information in the left column is also customized for patents to show filing and publication date. Issue #374

__Note:__ The patent collection handle number on lines 416 and 376 must be changed to match that of whatever server you are on.

The XSL rule that displayed dc.contributor.* for all items' summary view was changed to show the specific fields dc.contributor.author (if present) and dc.contributor.inventor for patents. The previous rule was causing redundant information to show.