### PR TITLE
Fix deposit when manually entering journal title

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/sherpa/submit/SHERPASubmitService.java
+++ b/dspace-api/src/main/java/org/dspace/app/sherpa/submit/SHERPASubmitService.java
@@ -72,7 +72,10 @@ public class SHERPASubmitService
             {
                 for (String eIssn : eIssns)
                 {
-                    issns.add(eIssn.trim());
+                    if (eIssn != null)
+                    {
+                        issns.add(eIssn.trim());
+                    }
                 }
             }
         }


### PR DESCRIPTION
This fixes VTechWorks issue #466, problem depositing article
when manually entering journal title instead of using SHERPA lookup.