### PR TITLE
Show general audience abstract in simple item view

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/vtmirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -290,6 +290,34 @@
                 </div>
             </div>
         </xsl:if>
+        <xsl:if test="dim:field[@element='description' and @qualifier='abstractgeneral']">
+            <div class="simple-item-view-description item-page-field-wrapper table">
+                <h5><i18n:text>xmlui.dri2xhtml.METS-1.0.item-abstract-general</i18n:text></h5>
+                <!-- Show line break in abstract field. -->
+                <div class="line-break">
+                    <xsl:for-each select="dim:field[@element='description' and @qualifier='abstractgeneral']">
+                        <xsl:choose>
+                            <xsl:when test="node()">
+                                <!-- html encoding for abstracts -->
+                            	<!--
+                                <xsl:copy-of select="node()"/>
+                                -->
+                                <xsl:value-of select="node()" disable-output-escaping="yes" />
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:text>&#160;</xsl:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                        <xsl:if test="count(following-sibling::dim:field[@element='description' and @qualifier='abstract']) != 0">
+                            <div class="spacer">&#160;</div>
+                        </xsl:if>
+                    </xsl:for-each>
+                    <xsl:if test="count(dim:field[@element='description' and @qualifier='abstract']) &gt; 1">
+                        <div class="spacer">&#160;</div>
+                    </xsl:if>
+                </div>
+            </div>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template name="itemSummaryView-DIM-authors">

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2255,6 +2255,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-title">Title</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-author">Author</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-abstract">Abstract</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-abstract-general">General Audience Abstract</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-description">Description</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-uri">URI</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-date">Date</message>


### PR DESCRIPTION
For issue #468. General abstract now appears in simple item view (if it exists). Looks like:

<img width="870" alt="screen shot 2017-03-15 at 1 08 54 pm" src="https://cloud.githubusercontent.com/assets/7339589/23961257/c1986e60-0980-11e7-9223-a744e1a71109.png">
