### PR TITLE
OMALS uses VTETDUploadStep now

### DIFF
--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -326,7 +326,7 @@
 				<heading>submit.progressbar.upload</heading>
 				<processing-class>org.dspace.submit.step.UploadWithEmbargoStep</processing-class>
 				<jspui-binding>org.dspace.app.webui.submit.step.JSPUploadWithEmbargoStep</jspui-binding>
-				<xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.UploadWithEmbargoStep</xmlui-binding>
+				<xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.VTETDUploadStep</xmlui-binding>
 				<workflow-editable>true</workflow-editable>
 			</step>
 


### PR DESCRIPTION
Addresses issue #475. OMALS uses the VTETDUpload step instead of UploadWithEmbargo step