### PR TITLE
Sword http fix

### DIFF
--- a/dspace/config/modules/sword-server.cfg
+++ b/dspace/config/modules/sword-server.cfg
@@ -195,3 +195,8 @@ plugin.named.org.dspace.sword.SWORDIngester = \
   org.dspace.sword.SWORDMETSIngester = http://purl.org/net/sword-types/METSDSpaceSIP \
   org.dspace.sword.SimpleFileIngester = SimpleFileIngester
 
+# Use http://hostname for all paths
+deposit.url = http://${dspace.hostname}/sword/deposit
+servicedocument.url = http://${dspace.hostname}/sword/servicedocument
+
+

--- a/dspace/config/modules/swordv2-server.cfg
+++ b/dspace/config/modules/swordv2-server.cfg
@@ -463,4 +463,8 @@ state.withdrawn.description = The item has been withdrawn from the archive and i
 # XMLUI
 workspace.url-template = http://localhost:8080/xmlui/submit?workspaceID=#wsid#
 
+# Use http://hostname for all paths
+collection.url = http://${dspace.hostname}/swordv2/collection
+servicedocument.url = http://${dspace.hostname}/swordv2/servicedocument
+
 


### PR DESCRIPTION
I modified both swordv1 and swordv2 so they use http://hostname for deposit urls. It works fine on my LDE and I think it would work on the real servers, since hostnames are set correctly.

Addresses issue #491