### PR TITLE
Corrected DOI URL in submission instructions

### DIFF
--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -97,7 +97,7 @@
 					<repeatable>true</repeatable>
 					<label>Identifiers</label>
 					<input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
-					<hint>If the item has any identification numbers or codes associated with it, please enter them. Examples: DOI 10.1056/NEJMoa1510991, URL http://www.johncairns.net/ebook2.htm, ISSN 0272-3638</hint>
+					<hint>If the item has any identification numbers or codes associated with it, please enter them. Examples: https://doi.org/10.1056/NEJMoa1510991, URL http://www.johncairns.net/ebook2.htm, ISSN 0272-3638</hint>
 					<required></required>
 				</field>
 
@@ -811,7 +811,7 @@
 					<repeatable>true</repeatable>
 					<label>Identifiers</label>
 					<input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
-					<hint>If the item has any identification numbers or codes associated with it, please enter them. Examples: DOI 10.1056/NEJMoa1510991, exam number VT5653, URL http://www.johncairns.net/ebook2.htm</hint>
+					<hint>If the item has any identification numbers or codes associated with it, please enter them. Examples: https://doi.org/10.1056/NEJMoa1510991, exam number VT5653, URL http://www.johncairns.net/ebook2.htm</hint>
 					<required></required>
 				</field>
 


### PR DESCRIPTION
I have updated the instructions for DOI URL entries. @alawvt @pyc1 please see the before and after screenshots.

<img width="900" alt="DOI_before" src="https://user-images.githubusercontent.com/473202/71116614-7afc6000-21a2-11ea-916c-6b3d515c21c8.png">

<img width="900" alt="DOI_after" src="https://user-images.githubusercontent.com/473202/71116627-7e8fe700-21a2-11ea-892d-f12ecc57cac9.png">
