### PR TITLE
reorder CC license descriptions

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -973,15 +973,16 @@
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
         <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">An error occurred ... {0}</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.head">License Your Work</message>
-        <message key="xmlui.Submission.submit.CCLicenseStep.info1"><p>Let people know whether and how they may use this work. Learn more at <strong><a href="http://creativecommons.org" title="Creative Commons" target="_blank">Creative Commons.</a></strong></p>
-<h4>Public Domain - no known copyright</h4>
-<p>The Public Domain mark by Creative Commons indicates that neither you nor anyone else currently has rights to the work. Common reasons for a work to be in the public domain include because its copyright has expired, because it was created by a government body, or because it is factual and therefore does not meet the copyright standard for original creative expression. The Public Domain mark is most often appropriate for texts and images published before the early 20th century, government documents, datasets, graphs, and charts.</p>
-<h4>CC0 - no rights reserved</h4>
-<p>CC0 ("Creative Commons Zero") enables you to waive your rights in your works and thereby place them as completely as possible in the public domain, so that others may freely build upon, enhance, and reuse your works for any purposes without restriction under copyright or database law.</p>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">
+<p>Let people know whether and how they may use this work. Learn more at <strong><a href="http://creativecommons.org" title="Creative Commons" target="_blank">Creative Commons.</a></strong></p>
 <h4>Creative Commons - some rights reserved</h4>
 <p>Creative Commons licenses allow you to retain some rights: this option will let you decide and declare whether to allow or refuse permission for commercial uses of your work, whether to allow or refuse permission to modify your work, or whether to allow modifications of your work only on the condition that modifiers also allow others to modify the new work ("ShareAlike").</p>
 <h4>No Creative Commons license</h4>
-<p>You need not specify a Creative Commons license or mark for the work you are uploading, but in that case, people who find the content online will not know whether or how they are permitted to use, share, redistribute, remix, tweak, and build upon your work.</p></message>
+<p>You need not specify a Creative Commons license or mark for the work you are uploading, but in that case, people who find the content online will not know whether or how they are permitted to use, share, redistribute, remix, tweak, and build upon your work.</p>
+<h4>CC0 - no rights reserved</h4>
+<p>CC0 ("Creative Commons Zero") enables you to waive your rights in your works and thereby place them as completely as possible in the public domain, so that others may freely build upon, enhance, and reuse your works for any purposes without restriction under copyright or database law.</p>
+<h4>Public Domain - no known copyright</h4>
+<p>The Public Domain mark by Creative Commons indicates that neither you nor anyone else currently has rights to the work. Common reasons for a work to be in the public domain include because its copyright has expired, because it was created by a government body, or because it is factual and therefore does not meet the copyright standard for original creative expression. The Public Domain mark is most often appropriate for texts and images published before the early 20th century, government documents, datasets, graphs, and charts.</p></message>
         
 <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Choose a license</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Proceed to Creative Commons website to select a license</message>


### PR DESCRIPTION
resolves #676 

CC license step before
<img width="804" alt="CCDescriptionOrderBefore" src="https://user-images.githubusercontent.com/13037168/71264043-38a56100-2311-11ea-9e7a-cbc96d050256.png">
CC license step after
<img width="784" alt="CCDescriptionOrderAfter" src="https://user-images.githubusercontent.com/13037168/71264063-41963280-2311-11ea-939a-549387b4c8c5.png">
