### PR TITLE
Enable text indexing of WebVTT caption files

### DIFF
--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -229,7 +229,8 @@ org.dspace.app.mediafilter.ImageMagickThumbnailFilter.bitstreamDescription = IM 
 # bitstream descriptions that do not conform to the following regular expression will not be overwritten
 org.dspace.app.mediafilter.ImageMagickThumbnailFilter.replaceRegex = ^Generated Thumbnail$
 
-
+# Enable text indexing of WebVTT caption files
+filter.org.dspace.app.mediafilter.HTMLFilter.inputFormats = HTML, Text, WebVTT caption file
 ### Item export and download settings ###
 
 # The maximum size in Megabytes the export should be.  This is enforced before the

--- a/dspace/config/registries/bitstream-formats.xml
+++ b/dspace/config/registries/bitstream-formats.xml
@@ -742,4 +742,31 @@
       <extension>epub</extension>
     </bitstream-type>
 
+<bitstream-type>
+      <mimetype>video/mp4</mimetype>
+      <short_description>MP4 Container</short_description>
+      <description>MP4 Container format for video files</description>
+      <support_level>0</support_level>
+      <internal>false</internal>
+      <extension>m4v</extension>
+      <extension>mp4</extension>
+    </bitstream-type>
+
+    <bitstream-type>
+      <mimetype>video/webm</mimetype>
+      <short_description>webm video</short_description>
+      <description>The webm video container format</description>
+      <support_level>0</support_level>
+      <internal>false</internal>
+      <extension>webm</extension>
+    </bitstream-type>
+
+    <bitstream-type>
+      <mimetype>text/vtt</mimetype>
+      <short_description>WebVTT caption file</short_description>
+      <description>Closed caption or subtitle file for HTML5 video</description>
+      <support_level>1</support_level>
+      <internal>false</internal>
+      <extension>vtt</extension>
+    </bitstream-type>
 </dspace-bitstream-types>


### PR DESCRIPTION
This feature had been previously enabled, but
seems to have been inadvertently lost during
an upgrade.

This is a duplicate of branch, webvtt_indexing as one commit.