### PR TITLE
Limit the number of log files that are retained.

### DIFF
--- a/dspace/config/log4j-solr.properties
+++ b/dspace/config/log4j-solr.properties
@@ -31,6 +31,8 @@ log4j.appender.CONSOLE.layout.ConversionPattern=%-4r [%t] %-5p %c %x \u2013 %m%n
 log4j.appender.file=org.apache.log4j.DailyRollingFileAppender
 # Set this to yyyy-MM-DD for daily log files, or yyyy-MM for monthly files
 log4j.appender.file.DatePattern='.'yyyy-MM-dd
+# The number of log files to keep, or 0 to keep them all
+log4j.appender.file.MaxLogs=60
 
 #- File to log to and log format
 log4j.appender.file.File=${log.dir}/solr.log

--- a/dspace/config/log4j.properties
+++ b/dspace/config/log4j.properties
@@ -49,7 +49,7 @@ log4j.appender.A1.File=${log.dir}/dspace.log
 # Set this to yyyy-MM-DD for daily log files, or yyyy-MM for monthly files
 log4j.appender.A1.DatePattern=yyyy-MM-dd
 # The number of log files to keep, or 0 to keep them all
-log4j.appender.A1.MaxLogs=0
+log4j.appender.A1.MaxLogs=60
 # A1 uses PatternLayout.
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d %-5p %c @ %m%n
@@ -70,7 +70,7 @@ log4j.appender.A2.File=${log.dir}/checker.log
 # Set this to yyyy-MM-DD for daily log files, or yyyy-MM for monthly files
 log4j.appender.A2.DatePattern=yyyy-MM-dd
 # The number of log files to keep, or 0 to keep them all
-log4j.appender.A2.MaxLogs=0
+log4j.appender.A2.MaxLogs=60
 # A2 uses PatternLayout.
 log4j.appender.A2.layout=org.apache.log4j.PatternLayout
 log4j.appender.A2.layout.ConversionPattern=%m%n


### PR DESCRIPTION
The current log settings configure the logger with "MaxLogs=0".
This means no old log files are deleted after log rotation.
Instead, we avoid runaway log file accumulation by setting a
non-zero value for "MaxLogs".